### PR TITLE
feat: add Pre-Mesa testnet network

### DIFF
--- a/e2e/explorer.spec.ts
+++ b/e2e/explorer.spec.ts
@@ -252,7 +252,7 @@ test.describe('Network Picker', () => {
     // Click on network selector dropdown (use first for desktop)
     const networkButton = page
       .locator('header button')
-      .filter({ hasText: /Mesa|Devnet|Mainnet/ })
+      .filter({ hasText: /Pre-Mesa|Mesa|Devnet|Mainnet/ })
       .first();
     await expect(networkButton).toBeVisible();
     await networkButton.click();
@@ -292,7 +292,7 @@ test.describe('Network Picker', () => {
     // Click on network selector (use first for desktop)
     const networkButton = page
       .locator('header button')
-      .filter({ hasText: /Mesa|Devnet|Mainnet/ })
+      .filter({ hasText: /Pre-Mesa|Mesa|Devnet|Mainnet/ })
       .first();
     await networkButton.click();
 
@@ -325,7 +325,7 @@ test.describe('Network Picker', () => {
     // Click on network selector (use first for desktop)
     const networkButton = page
       .locator('header button')
-      .filter({ hasText: /Mesa|Devnet|Mainnet/ })
+      .filter({ hasText: /Pre-Mesa|Mesa|Devnet|Mainnet/ })
       .first();
     await networkButton.click();
 
@@ -349,7 +349,7 @@ test.describe('Network Picker', () => {
     // Switch to Devnet (use first for desktop)
     const networkButton = page
       .locator('header button')
-      .filter({ hasText: /Mesa|Devnet|Mainnet/ })
+      .filter({ hasText: /Pre-Mesa|Mesa|Devnet|Mainnet/ })
       .first();
     await networkButton.click();
 
@@ -401,7 +401,7 @@ test.describe('Network Picker', () => {
     // Switch to Devnet (use first for desktop)
     const networkButton = page
       .locator('header button')
-      .filter({ hasText: /Mesa|Devnet|Mainnet/ })
+      .filter({ hasText: /Pre-Mesa|Mesa|Devnet|Mainnet/ })
       .first();
     await networkButton.click();
 
@@ -422,7 +422,7 @@ test.describe('Network Picker', () => {
     // Switch to Mainnet (use first for desktop)
     const networkButton = page
       .locator('header button')
-      .filter({ hasText: /Mesa|Devnet|Mainnet/ })
+      .filter({ hasText: /Pre-Mesa|Mesa|Devnet|Mainnet/ })
       .first();
     await networkButton.click();
 
@@ -471,7 +471,7 @@ test.describe('Network Picker', () => {
     // Switch to Devnet (use first for desktop)
     const networkButton = page
       .locator('header button')
-      .filter({ hasText: /Mesa|Devnet|Mainnet/ })
+      .filter({ hasText: /Pre-Mesa|Mesa|Devnet|Mainnet/ })
       .first();
     await networkButton.click();
 

--- a/e2e/network-endpoints.spec.ts
+++ b/e2e/network-endpoints.spec.ts
@@ -107,7 +107,7 @@ test.describe('Network Endpoints Integration', () => {
       // Switch to Mainnet
       const networkButton = page
         .locator('header button')
-        .filter({ hasText: /Mesa|Devnet|Mainnet/ })
+        .filter({ hasText: /Pre-Mesa|Mesa|Devnet|Mainnet/ })
         .first();
       await networkButton.click();
       await page.locator('button:has-text("Mainnet")').first().click();
@@ -153,7 +153,7 @@ test.describe('Network Endpoints Integration', () => {
       // Switch to Devnet
       const networkButton = page
         .locator('header button')
-        .filter({ hasText: /Mesa|Devnet|Mainnet/ })
+        .filter({ hasText: /Pre-Mesa|Mesa|Devnet|Mainnet/ })
         .first();
       await networkButton.click();
       await page.locator('button:has-text("Devnet")').first().click();
@@ -202,7 +202,7 @@ test.describe('Network Endpoints Integration', () => {
       // Switch to Mainnet
       const networkButton = page
         .locator('header button')
-        .filter({ hasText: /Mesa|Devnet|Mainnet/ })
+        .filter({ hasText: /Pre-Mesa|Mesa|Devnet|Mainnet/ })
         .first();
       await networkButton.click();
       await page.locator('button:has-text("Mainnet")').first().click();
@@ -242,7 +242,7 @@ test.describe('Network Endpoints Integration', () => {
       await page.goto('/');
       const networkButton = page
         .locator('header button')
-        .filter({ hasText: /Mesa|Devnet|Mainnet/ })
+        .filter({ hasText: /Pre-Mesa|Mesa|Devnet|Mainnet/ })
         .first();
       await networkButton.click();
       await page.locator('button:has-text("Mainnet")').first().click();
@@ -275,7 +275,7 @@ test.describe('Network Endpoints Integration', () => {
       await page.goto('/');
       const networkButton = page
         .locator('header button')
-        .filter({ hasText: /Mesa|Devnet|Mainnet/ })
+        .filter({ hasText: /Pre-Mesa|Mesa|Devnet|Mainnet/ })
         .first();
       await networkButton.click();
       await page.locator('button:has-text("Mainnet")').first().click();

--- a/src/components/accounts/AccountDetail.tsx
+++ b/src/components/accounts/AccountDetail.tsx
@@ -24,6 +24,7 @@ function getMinaScanNetwork(networkId?: string): string {
       return 'mainnet';
     case 'devnet':
     case 'mesa':
+    case 'pre-mesa':
       return 'devnet';
     default:
       return 'mainnet';

--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -18,6 +18,15 @@ export interface NetworkConfig {
 }
 
 export const NETWORKS: Record<string, NetworkConfig> = {
+  'pre-mesa': {
+    id: 'pre-mesa',
+    name: 'pre-mesa',
+    displayName: 'Pre-Mesa',
+    archiveEndpoint: 'https://pre-mesa-archive-node-api.gcp.o1test.net',
+    daemonEndpoint:
+      'https://plain-1-graphql.hetzner-pre-mesa-1.gcp.o1test.net/graphql',
+    isTestnet: true,
+  },
   mesa: {
     id: 'mesa',
     name: 'mesa',


### PR DESCRIPTION
  Add pre-mesa testnet with archive (pre-mesa-archive-node-api.gcp.o1test.net)
  and daemon (plain-1-graphql.hetzner-pre-mesa-1.gcp.o1test.net) endpoints.
  Update MinaScan mapping and e2e test network selector patterns.