### PR TITLE
feat: paginated confirmed transactions + block detail via archive and…

### DIFF
--- a/e2e/fixtures/confirmed-transactions.json
+++ b/e2e/fixtures/confirmed-transactions.json
@@ -1,107 +1,83 @@
 {
   "data": {
-    "bestChain": [
+    "blocks": [
       {
-        "stateHash": "3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ",
-        "protocolState": {
-          "consensusState": {
-            "blockHeight": "432148"
-          },
-          "blockchainState": {
-            "date": "1738670640000"
-          }
-        },
-        "transactions": {
-          "userCommands": [],
-          "zkappCommands": []
-        }
-      },
-      {
-        "stateHash": "3NKaBxR5XG6Sdc8q5CXH1TbXgMCCKjhxGLpRuVkTAqAd1bKg7nPf",
-        "protocolState": {
-          "consensusState": {
-            "blockHeight": "432149"
-          },
-          "blockchainState": {
-            "date": "1738670820000"
-          }
-        },
-        "transactions": {
-          "userCommands": [
-            {
-              "hash": "CkpZwt2Hy1Dv2HnKfBMwQJRj4hXBRfNVqy8xPZw2TnEq5wDKdJrWr",
-              "kind": "PAYMENT",
-              "from": "B62qpge4uMq4Vv5Rvc8Gw9qSquUYd6xoW1pz7HQkMSHm6h1o7pvLPAN",
-              "to": "B62qoG5Yk4iVxpyczUrBNpwtx2xunPhxfG7yYA3xYBPJeRbABxvWC3K",
-              "amount": "2500000000",
-              "fee": "15000000",
-              "memo": "E4YmF9dJ7jBXyD2dKPGRfEtYsZ82fQ2UL3bpB3YVuTCxkcZ6YqVKd",
-              "nonce": 789,
-              "failureReason": null
-            }
-          ],
-          "zkappCommands": []
-        }
-      },
-      {
-        "stateHash": "3NKrE8zVUWyHNvM4KTCpL2abJ8ZwLUjJmcCgwTuXA5qF4RkShVhN",
-        "protocolState": {
-          "consensusState": {
-            "blockHeight": "432150"
-          },
-          "blockchainState": {
-            "date": "1738671000000"
-          }
-        },
+        "blockHeight": 432150,
+        "dateTime": "2026-02-04T12:30:00.000Z",
         "transactions": {
           "userCommands": [
             {
               "hash": "CkpZwt1Hy1Dv2HnKfBMwQJRj4hXBRfNVqy8xPZw2TnEq5wDKdJrWp",
-              "kind": "PAYMENT",
+              "kind": "payment",
               "from": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
               "to": "B62qpge4uMq4Vv5Rvc8Gw9qSquUYd6xoW1pz7HQkMSHm6h1o7pvLPAN",
               "amount": "1000000000",
               "fee": "10000000",
               "memo": "E4YmF9dJ7jBXyD2dKPGRfEtYsZ82fQ2UL3bpB3YVuTCxkcZ6YqVKd",
               "nonce": 123,
+              "status": "applied",
               "failureReason": null
             },
             {
               "hash": "CkpZwt1Hy1Dv2HnKfBMwQJRj4hXBRfNVqy8xPZw2TnEq5wDKdJrWq",
-              "kind": "STAKE_DELEGATION",
+              "kind": "stake_delegation",
               "from": "B62qoG5Yk4iVxpyczUrBNpwtx2xunPhxfG7yYA3xYBPJeRbABxvWC3K",
               "to": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
               "amount": "0",
               "fee": "5000000",
               "memo": "E4YM2vTHhWEg66xpj52JErHUBU4pZ1yageL4YNTv97JEVmSiaqifp",
               "nonce": 456,
+              "status": "applied",
               "failureReason": null
             }
           ],
           "zkappCommands": [
             {
               "hash": "5JuZkApp8jyKPXgVcNnQxD9JKMVLR4GzTxNHr6FqE3mYBdWy7ScPv",
-              "failureReasons": null,
-              "zkappCommand": {
-                "memo": "E4YM2vTHhWEg66xpj52JErHUBU4pZ1yageL4YNTv97JEVmSiaqifp",
-                "feePayer": {
-                  "body": {
-                    "publicKey": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
-                    "fee": "100000000"
-                  }
-                },
-                "accountUpdates": [
-                  {
-                    "body": {
-                      "publicKey": "B62qpge4uMq4Vv5Rvc8Gw9qSquUYd6xoW1pz7HQkMSHm6h1o7pvLPAN"
-                    }
-                  }
-                ]
-              }
+              "feePayer": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
+              "fee": "100000000",
+              "memo": "E4YM2vTHhWEg66xpj52JErHUBU4pZ1yageL4YNTv97JEVmSiaqifp",
+              "status": "applied",
+              "failureReason": null
             }
           ]
         }
+      },
+      {
+        "blockHeight": 432149,
+        "dateTime": "2026-02-04T12:27:00.000Z",
+        "transactions": {
+          "userCommands": [
+            {
+              "hash": "CkpZwt2Hy1Dv2HnKfBMwQJRj4hXBRfNVqy8xPZw2TnEq5wDKdJrWr",
+              "kind": "payment",
+              "from": "B62qpge4uMq4Vv5Rvc8Gw9qSquUYd6xoW1pz7HQkMSHm6h1o7pvLPAN",
+              "to": "B62qoG5Yk4iVxpyczUrBNpwtx2xunPhxfG7yYA3xYBPJeRbABxvWC3K",
+              "amount": "2500000000",
+              "fee": "15000000",
+              "memo": "E4YmF9dJ7jBXyD2dKPGRfEtYsZ82fQ2UL3bpB3YVuTCxkcZ6YqVKd",
+              "nonce": 789,
+              "status": "applied",
+              "failureReason": null
+            }
+          ],
+          "zkappCommands": []
+        }
+      },
+      {
+        "blockHeight": 432148,
+        "dateTime": "2026-02-04T12:24:00.000Z",
+        "transactions": {
+          "userCommands": [],
+          "zkappCommands": []
+        }
       }
-    ]
+    ],
+    "networkState": {
+      "maxBlockHeight": {
+        "canonicalMaxBlockHeight": 432148,
+        "pendingMaxBlockHeight": 432150
+      }
+    }
   }
 }

--- a/e2e/mock-api.ts
+++ b/e2e/mock-api.ts
@@ -196,8 +196,20 @@ async function handleArchiveRequest(route: Route): Promise<void> {
       return;
     }
 
+    // Handle paginated transaction queries (archive with transaction fields)
+    if (
+      query.includes('GetTransactions') ||
+      query.includes('GetTransactionsPaginated')
+    ) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(FIXTURE_DATA.confirmedTransactions),
+      });
+      return;
+    }
+
     // Handle block detail queries (with userCommands or zkappCommands)
-    // Note: feeTransfer alone is not sufficient as block list queries also include it
     if (
       query.includes('blocks') &&
       (query.includes('userCommands') || query.includes('zkappCommands'))

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -19,6 +19,7 @@ export {
   useTransaction,
   useAccountTransactions,
   useRecentTransactions,
+  usePaginatedTransactions,
 } from './useTransactions';
 export { usePrice } from './usePrice';
 export { useHistoricalPrice } from './useHistoricalPrice';

--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -5,6 +5,7 @@ import {
   fetchTransactionByHash,
   fetchAccountTransactions,
   fetchRecentTransactions,
+  fetchTransactionsPaginated,
   type PendingTransaction,
   type PendingZkAppCommand,
   type TransactionDetail,
@@ -273,6 +274,116 @@ export function useRecentTransactions(
     loading,
     error,
     blocksScanned,
+    page,
+    totalPages,
+    goToPage,
+    nextPage,
+    prevPage,
+    refresh,
+  };
+}
+
+interface UsePaginatedTransactionsResult {
+  transactions: ConfirmedTransaction[];
+  loading: boolean;
+  error: string | null;
+  hasMore: boolean;
+  totalBlockHeight: number;
+  page: number;
+  totalPages: number;
+  goToPage: (page: number) => void;
+  nextPage: () => void;
+  prevPage: () => void;
+  refresh: () => void;
+}
+
+export function usePaginatedTransactions(
+  blocksPerPage: number = 50,
+): UsePaginatedTransactionsResult {
+  const { network } = useNetwork();
+  const [transactions, setTransactions] = useState<ConfirmedTransaction[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [totalBlockHeight, setTotalBlockHeight] = useState(0);
+
+  const totalPages = Math.max(1, Math.ceil(totalBlockHeight / blocksPerPage));
+
+  const loadPage = useCallback(
+    async (pageNum: number, forceRefresh: boolean = false) => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        let cursor: number | undefined;
+        if (pageNum > 1 && totalBlockHeight > 0) {
+          cursor = totalBlockHeight - (pageNum - 1) * blocksPerPage + 1;
+          if (cursor <= 0) cursor = undefined;
+        }
+
+        const data = await fetchTransactionsPaginated(blocksPerPage, cursor);
+        setTransactions(data.transactions);
+        setHasMore(data.hasMore);
+
+        if (pageNum === 1 || forceRefresh || totalBlockHeight === 0) {
+          setTotalBlockHeight(data.totalBlockHeight);
+        }
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'Failed to fetch transactions',
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [blocksPerPage, totalBlockHeight],
+  );
+
+  useEffect(() => {
+    setPage(1);
+    setTotalBlockHeight(0);
+    loadPage(1, true);
+  }, [network.id, blocksPerPage]);
+
+  useEffect(() => {
+    if (totalBlockHeight > 0) {
+      loadPage(page);
+    }
+  }, [page, totalBlockHeight]);
+
+  const goToPage = useCallback(
+    (newPage: number) => {
+      if (newPage >= 1 && newPage <= totalPages) {
+        setPage(newPage);
+      }
+    },
+    [totalPages],
+  );
+
+  const nextPage = useCallback(() => {
+    if (page < totalPages) {
+      setPage(p => p + 1);
+    }
+  }, [page, totalPages]);
+
+  const prevPage = useCallback(() => {
+    if (page > 1) {
+      setPage(p => p - 1);
+    }
+  }, [page]);
+
+  const refresh = useCallback(() => {
+    setPage(1);
+    loadPage(1, true);
+  }, [loadPage]);
+
+  return {
+    transactions,
+    loading,
+    error,
+    hasMore,
+    totalBlockHeight,
     page,
     totalPages,
     goToPage,

--- a/src/pages/TransactionsPage.tsx
+++ b/src/pages/TransactionsPage.tsx
@@ -10,7 +10,7 @@ import {
 import { HashLink, Amount, LoadingSpinner } from '@/components/common';
 import { TransactionList } from '@/components/transactions';
 import {
-  useRecentTransactions,
+  usePaginatedTransactions,
   usePendingTransactions,
   usePendingZkAppCommands,
   useNetwork,
@@ -30,17 +30,16 @@ export function TransactionsPage(): ReactNode {
 
   const {
     transactions: confirmedTxs,
-    allTransactions,
     loading: confirmedLoading,
     error: confirmedError,
-    blocksScanned,
+    totalBlockHeight,
     page,
     totalPages,
     goToPage,
     nextPage,
     prevPage,
     refresh: refreshConfirmed,
-  } = useRecentTransactions(30);
+  } = usePaginatedTransactions(50);
 
   const {
     transactions: pendingTxs,
@@ -64,10 +63,10 @@ export function TransactionsPage(): ReactNode {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">Transactions</h1>
-          {activeTab === 'confirmed' && blocksScanned > 0 && (
+          {activeTab === 'confirmed' && totalBlockHeight > 0 && (
             <p className="text-sm text-muted-foreground">
-              {formatNumber(allTransactions.length)} transactions from last{' '}
-              {blocksScanned} blocks on {network.displayName}
+              {formatNumber(totalBlockHeight)} total blocks on{' '}
+              {network.displayName}
             </p>
           )}
           {activeTab === 'mempool' && (

--- a/src/services/api/blocks.ts
+++ b/src/services/api/blocks.ts
@@ -34,6 +34,7 @@ const BLOCKS_QUERY_FULL = `
     networkState {
       maxBlockHeight {
         canonicalMaxBlockHeight
+        pendingMaxBlockHeight
       }
     }
   }
@@ -63,6 +64,7 @@ const BLOCKS_QUERY_BASIC = `
     networkState {
       maxBlockHeight {
         canonicalMaxBlockHeight
+        pendingMaxBlockHeight
       }
     }
   }
@@ -86,6 +88,7 @@ const BLOCKS_QUERY_MINIMAL = `
     networkState {
       maxBlockHeight {
         canonicalMaxBlockHeight
+        pendingMaxBlockHeight
       }
     }
   }
@@ -206,6 +209,7 @@ const BLOCK_DETAIL_QUERY = `
     networkState {
       maxBlockHeight {
         canonicalMaxBlockHeight
+        pendingMaxBlockHeight
       }
     }
   }
@@ -229,6 +233,7 @@ const BLOCK_BY_HEIGHT_QUERY = `
     networkState {
       maxBlockHeight {
         canonicalMaxBlockHeight
+        pendingMaxBlockHeight
       }
     }
   }
@@ -318,6 +323,7 @@ interface BlockDetailResponse {
   networkState: {
     maxBlockHeight: {
       canonicalMaxBlockHeight: number;
+      pendingMaxBlockHeight: number;
     };
   };
 }
@@ -327,6 +333,7 @@ interface BlocksResponse {
   networkState: {
     maxBlockHeight: {
       canonicalMaxBlockHeight: number;
+      pendingMaxBlockHeight: number;
     };
   };
 }

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -9,8 +9,10 @@ export {
 } from './blocks';
 export { fetchAccount } from './accounts';
 export {
+  fetchTransactionsPaginated,
   fetchRecentTransactions,
   type ConfirmedTransaction,
+  type TransactionsPageResult,
   type RecentTransactionsResult,
 } from './transactions';
 export {

--- a/src/services/api/transactions.ts
+++ b/src/services/api/transactions.ts
@@ -529,6 +529,221 @@ export interface ConfirmedTransaction {
   failureReason?: string | null | undefined;
 }
 
+export interface TransactionsPageResult {
+  transactions: ConfirmedTransaction[];
+  hasMore: boolean;
+  nextCursor: number | null;
+  totalBlockHeight: number;
+}
+
+// Archive queries for confirmed transactions (requires Archive-Node-API PR 148+)
+const TRANSACTIONS_ARCHIVE_QUERY = `
+  query GetTransactions($limit: Int!) {
+    blocks(
+      limit: $limit
+      sortBy: BLOCKHEIGHT_DESC
+    ) {
+      blockHeight
+      dateTime
+      transactions {
+        userCommands {
+          hash
+          kind
+          from
+          to
+          amount
+          fee
+          memo
+          nonce
+          status
+          failureReason
+        }
+        zkappCommands {
+          hash
+          feePayer
+          fee
+          memo
+          status
+          failureReason
+        }
+      }
+    }
+    networkState {
+      maxBlockHeight {
+        canonicalMaxBlockHeight
+        pendingMaxBlockHeight
+      }
+    }
+  }
+`;
+
+const TRANSACTIONS_ARCHIVE_QUERY_PAGINATED = `
+  query GetTransactionsPaginated($limit: Int!, $maxBlockHeight: Int!) {
+    blocks(
+      query: { blockHeight_lt: $maxBlockHeight }
+      limit: $limit
+      sortBy: BLOCKHEIGHT_DESC
+    ) {
+      blockHeight
+      dateTime
+      transactions {
+        userCommands {
+          hash
+          kind
+          from
+          to
+          amount
+          fee
+          memo
+          nonce
+          status
+          failureReason
+        }
+        zkappCommands {
+          hash
+          feePayer
+          fee
+          memo
+          status
+          failureReason
+        }
+      }
+    }
+    networkState {
+      maxBlockHeight {
+        canonicalMaxBlockHeight
+        pendingMaxBlockHeight
+      }
+    }
+  }
+`;
+
+interface ArchiveTransactionBlock {
+  blockHeight: number;
+  dateTime: string;
+  transactions: {
+    userCommands: Array<{
+      hash: string;
+      kind: string;
+      from: string;
+      to: string;
+      amount: string;
+      fee: string;
+      memo: string;
+      nonce: number;
+      status: string;
+      failureReason: string | null;
+    }>;
+    zkappCommands: Array<{
+      hash: string;
+      feePayer: string;
+      fee: string;
+      memo: string;
+      status: string;
+      failureReason: string | null;
+    }>;
+  };
+}
+
+interface ArchiveTransactionsResponse {
+  blocks: ArchiveTransactionBlock[];
+  networkState: {
+    maxBlockHeight: {
+      canonicalMaxBlockHeight: number;
+      pendingMaxBlockHeight: number;
+    };
+  };
+}
+
+function flattenArchiveBlocks(
+  blocks: ArchiveTransactionBlock[],
+): ConfirmedTransaction[] {
+  const txs: ConfirmedTransaction[] = [];
+
+  for (const block of blocks) {
+    for (const cmd of block.transactions.userCommands || []) {
+      const kindUpper = cmd.kind.toUpperCase();
+      txs.push({
+        hash: cmd.hash,
+        type: kindUpper === 'STAKE_DELEGATION' ? 'delegation' : 'payment',
+        kind: kindUpper,
+        from: cmd.from,
+        to: cmd.to,
+        amount: cmd.amount,
+        fee: cmd.fee,
+        memo: cmd.memo,
+        nonce: cmd.nonce,
+        blockHeight: block.blockHeight,
+        dateTime: block.dateTime,
+        failureReason: cmd.failureReason,
+      });
+    }
+
+    for (const cmd of block.transactions.zkappCommands || []) {
+      txs.push({
+        hash: cmd.hash,
+        type: 'zkapp',
+        from: cmd.feePayer,
+        fee: cmd.fee,
+        memo: cmd.memo,
+        blockHeight: block.blockHeight,
+        dateTime: block.dateTime,
+        failureReason: cmd.failureReason,
+      });
+    }
+  }
+
+  return txs;
+}
+
+export async function fetchTransactionsPaginated(
+  blocksPerPage: number = 50,
+  beforeHeight?: number,
+): Promise<TransactionsPageResult> {
+  const client = getClient();
+
+  try {
+    const query = beforeHeight
+      ? TRANSACTIONS_ARCHIVE_QUERY_PAGINATED
+      : TRANSACTIONS_ARCHIVE_QUERY;
+    const variables: Record<string, unknown> = { limit: blocksPerPage };
+    if (beforeHeight) {
+      variables.maxBlockHeight = beforeHeight;
+    }
+
+    const data = await client.query<ArchiveTransactionsResponse>(
+      query,
+      variables,
+    );
+    const totalHeight = data.networkState.maxBlockHeight.pendingMaxBlockHeight;
+    const transactions = flattenArchiveBlocks(data.blocks);
+    const lastBlock = data.blocks[data.blocks.length - 1];
+
+    return {
+      transactions,
+      hasMore: lastBlock ? lastBlock.blockHeight > 1 : false,
+      nextCursor: lastBlock ? lastBlock.blockHeight : null,
+      totalBlockHeight: totalHeight,
+    };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : '';
+    if (msg.includes('Cannot query field')) {
+      // Archive doesn't support transaction fields — fall back to daemon
+      console.log(
+        '[API] Archive does not support transaction fields, falling back to daemon...',
+      );
+      const daemon = await fetchRecentTransactions();
+      return {
+        transactions: daemon.transactions,
+        hasMore: false,
+        nextCursor: null,
+        totalBlockHeight: daemon.newestBlockHeight,
+      };
+    }
+    throw error;
+  }
+}
+
 export interface RecentTransactionsResult {
   transactions: ConfirmedTransaction[];
   blocksScanned: number;


### PR DESCRIPTION
… daemon

  Add confirmed transactions page with server-side pagination using archive
  node (PR 148 Archive-Node-API). Falls back to daemon bestChain() for
  networks without the archive extension. Block detail page now fetches
  transaction data from daemon, with archive as primary when available.

  Changes:
  - Tabbed transactions page: Confirmed (paginated) + Mempool (user/zkapp tabs)
  - TransactionList component with type badges (payment/delegation/zkapp)
  - daemon.ts shared utility for daemon GraphQL queries
  - Archive-based fetchTransactionsPaginated() with daemon fallback
  - Block detail enriched with transactions from daemon block(height)
  - generatePageNumbers() extracted to shared pagination utility
  - Fix: blocks pagination missing pendingMaxBlockHeight in queries
  - Fix: mesa daemon endpoint (was incorrectly pointing to devnet)
  - Fix: transactions.json e2e fixture field format (caused React crash)
  - Fix: confirmed-transactions fixture matches real archive response
  - 6 new e2e tests for transactions page

  Architecture: Archive provides full block history but transaction fields
  require Archive-Node-API PR 148 (ENABLE_BLOCK_TRANSACTION_DETAILS flag).
  Daemon provides transaction data for ~290 recent blocks as fallback.