### PR TITLE
fix: CI flaky tests + epoch/slot display from daemon

### DIFF
--- a/e2e/explorer.spec.ts
+++ b/e2e/explorer.spec.ts
@@ -8,9 +8,7 @@ test.describe('Mina Explorer', () => {
     await expect(page).toHaveTitle(/Mina Explorer/);
 
     // Check header logo link (Mina is an image + "Explorer" text)
-    await expect(
-      page.locator('header a').filter({ hasText: 'Explorer' }).first(),
-    ).toBeVisible();
+    await expect(page.locator('header a').first()).toBeVisible();
 
     // Check search bar is present (use first() to handle multiple)
     await expect(
@@ -218,7 +216,7 @@ test.describe('Mina Explorer', () => {
     await expect(page).toHaveURL(/\/blocks/);
 
     // Click on logo to go back home
-    await page.locator('header a:has-text("Explorer")').first().click();
+    await page.locator('header a').first().click();
     await expect(page).toHaveURL(/\/#?\/?$/);
   });
 
@@ -370,7 +368,7 @@ test.describe('Network Picker', () => {
     ).toBeVisible();
 
     // Navigate back to home
-    await page.locator('header a:has-text("Explorer")').first().click();
+    await page.locator('header a').first().click();
 
     // Verify Devnet is still selected
     await expect(
@@ -435,9 +433,7 @@ test.describe('Network Picker', () => {
     await page.reload();
 
     // Wait for page to load (check header logo link)
-    await expect(
-      page.locator('header a').filter({ hasText: 'Explorer' }).first(),
-    ).toBeVisible();
+    await expect(page.locator('header a').first()).toBeVisible();
 
     // Verify Mainnet is still selected after refresh
     await expect(

--- a/e2e/mock-api.ts
+++ b/e2e/mock-api.ts
@@ -269,13 +269,57 @@ async function handleDaemonRequest(route: Route): Promise<void> {
     const body = JSON.parse(postData);
     const query = body.query || '';
 
-    // Handle bestChain queries (daemon transaction listing)
+    // Handle bestChain queries (daemon epoch info + transaction listing)
     // Must be checked before 'account' since bestChain queries contain 'accountUpdates'
     if (query.includes('bestChain')) {
+      // Epoch info query (small bestChain with protocolState)
+      if (query.includes('epoch') || query.includes('slot')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: {
+              bestChain: [
+                {
+                  protocolState: {
+                    consensusState: {
+                      blockHeight: '432150',
+                      epoch: '61',
+                      slot: '3570',
+                      slotSinceGenesis: '436710',
+                    },
+                  },
+                },
+              ],
+            },
+          }),
+        });
+        return;
+      }
+
+      // Transaction listing query — return confirmed transactions fixture
+      // Remap archive format to daemon bestChain format
+      const blocks = FIXTURE_DATA.confirmedTransactions.data.blocks;
+      const bestChain = blocks.map(
+        (b: {
+          blockHeight: number;
+          dateTime: string;
+          transactions: object;
+        }) => ({
+          stateHash: `3NK${b.blockHeight}`,
+          protocolState: {
+            consensusState: { blockHeight: String(b.blockHeight) },
+            blockchainState: {
+              date: String(new Date(b.dateTime).getTime()),
+            },
+          },
+          transactions: b.transactions,
+        }),
+      );
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(FIXTURE_DATA.confirmedTransactions),
+        body: JSON.stringify({ data: { bestChain } }),
       });
       return;
     }

--- a/src/components/dashboard/NetworkStats.tsx
+++ b/src/components/dashboard/NetworkStats.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useNetworkState, useNetwork, useBlocks } from '@/hooks';
+import { useNetworkState, useNetwork, useEpochInfo } from '@/hooks';
 import { formatNumber } from '@/utils/formatters';
 import { LoadingSpinner } from '@/components/common';
 
@@ -24,12 +24,10 @@ function StatCard({
 export function NetworkStats(): ReactNode {
   const { networkState, loading, error } = useNetworkState();
   const { network } = useNetwork();
-  const { blocks } = useBlocks(1);
+  const { epochInfo } = useEpochInfo();
 
-  // Get epoch info from the latest block
-  const latestBlock = blocks?.[0];
-  const epoch = latestBlock?.epoch;
-  const slot = latestBlock?.slot;
+  const epoch = epochInfo?.epoch;
+  const slot = epochInfo?.slot;
   const slotProgress = slot
     ? ((slot / SLOTS_PER_EPOCH) * 100).toFixed(1)
     : null;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,6 +3,7 @@ export {
   usePaginatedBlocks,
   useBlock,
   useNetworkState,
+  useEpochInfo,
 } from './useBlocks';
 export { useSearch } from './useSearch';
 export { useNetwork } from './useNetwork';

--- a/src/hooks/useBlocks.ts
+++ b/src/hooks/useBlocks.ts
@@ -6,6 +6,7 @@ import {
   fetchBlockByHash,
   fetchNetworkState,
 } from '@/services/api';
+import { fetchEpochInfo, type EpochInfo } from '@/services/api/daemon';
 import { useNetwork } from './useNetwork';
 import type { BlockSummary, BlockDetail, NetworkState } from '@/types';
 
@@ -234,4 +235,24 @@ export function usePaginatedBlocks(
     prevPage,
     refresh,
   };
+}
+
+interface UseEpochInfoResult {
+  epochInfo: EpochInfo | null;
+  loading: boolean;
+}
+
+export function useEpochInfo(): UseEpochInfoResult {
+  const { network } = useNetwork();
+  const [epochInfo, setEpochInfo] = useState<EpochInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchEpochInfo()
+      .then(data => setEpochInfo(data))
+      .finally(() => setLoading(false));
+  }, [network.id]);
+
+  return { epochInfo, loading };
 }

--- a/src/services/api/daemon.ts
+++ b/src/services/api/daemon.ts
@@ -62,3 +62,51 @@ export function isDaemonUnavailableError(error: unknown): boolean {
 
 /** Max blocks to request from daemon in a single bestChain call */
 export const MAX_DAEMON_BLOCKS = 30;
+
+export interface EpochInfo {
+  epoch: number;
+  slot: number;
+  slotSinceGenesis: number;
+  blockHeight: number;
+}
+
+export async function fetchEpochInfo(): Promise<EpochInfo | null> {
+  try {
+    const data = await queryDaemon<{
+      bestChain: Array<{
+        protocolState: {
+          consensusState: {
+            blockHeight: string;
+            epoch: string;
+            slot: string;
+            slotSinceGenesis: string;
+          };
+        };
+      }>;
+    }>(`{
+      bestChain(maxLength: 1) {
+        protocolState {
+          consensusState {
+            blockHeight
+            epoch
+            slot
+            slotSinceGenesis
+          }
+        }
+      }
+    }`);
+
+    const block = data.bestChain?.[0];
+    if (!block) return null;
+
+    const cs = block.protocolState.consensusState;
+    return {
+      epoch: parseInt(cs.epoch, 10),
+      slot: parseInt(cs.slot, 10),
+      slotSinceGenesis: parseInt(cs.slotSinceGenesis, 10),
+      blockHeight: parseInt(cs.blockHeight, 10),
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
  Fix all 5 consistently failing e2e tests (issue #27):
  - Logo locator: header link has images only (no visible text), use 'header a' selector instead of hasText('Explorer')
  - Epoch/slot: fetch from daemon bestChain() since archive has no protocolState; add useEpochInfo hook + mock epoch data in e2e

  Also:
  - Add archive-based fetchTransactionsPaginated() with daemon fallback for networks without Archive-Node-API PR 148
  - Fix blocks pagination: all queries now request pendingMaxBlockHeight (was missing, causing pagination controls to never appear)