### PR TITLE
fix: mobile network selector clipped by overflow-hidden (#32)

### DIFF
--- a/e2e/explorer.spec.ts
+++ b/e2e/explorer.spec.ts
@@ -1186,3 +1186,71 @@ test.describe('Transactions Page', () => {
     await expect(page.locator('h1')).toContainText('Transactions');
   });
 });
+
+test.describe('Mobile Menu', () => {
+  // Hamburger button is the lg:hidden button in the header
+  const hamburger = '[data-testid="mobile-menu-button"]';
+
+  test('network selector is accessible on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/');
+
+    // Wait for page to load
+    await expect(page.locator('text=Block Height').first()).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Hamburger should be visible on mobile
+    await expect(page.locator(hamburger)).toBeVisible({ timeout: 5000 });
+
+    // Open mobile menu
+    await page.locator(hamburger).click();
+
+    // Wait for menu animation
+    await page.waitForTimeout(300);
+
+    // Network selector button should be visible in mobile menu
+    const networkButton = page.locator(
+      '[data-testid="mobile-network-selector"]',
+    );
+    await expect(networkButton).toBeVisible({ timeout: 5000 });
+
+    // Click to expand network list
+    await networkButton.click();
+
+    // Network options should be visible inline (not clipped)
+    await expect(
+      page.locator('button').filter({ hasText: 'Devnet' }).first(),
+    ).toBeVisible({ timeout: 5000 });
+    await expect(
+      page.locator('button').filter({ hasText: 'Mainnet' }).first(),
+    ).toBeVisible();
+  });
+
+  test('can switch network on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/');
+
+    // Wait for page to load
+    await expect(page.locator('text=Block Height').first()).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Open mobile menu
+    await expect(page.locator(hamburger)).toBeVisible({ timeout: 5000 });
+    await page.locator(hamburger).click();
+    await page.waitForTimeout(300);
+
+    // Open network selector
+    const networkButton = page.locator(
+      '[data-testid="mobile-network-selector"]',
+    );
+    await networkButton.click();
+
+    // Switch to Devnet
+    await page.locator('button').filter({ hasText: 'Devnet' }).first().click();
+
+    // Verify Devnet is now selected
+    await expect(networkButton).toContainText('Devnet', { timeout: 5000 });
+  });
+});

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -80,6 +80,7 @@ export function Header(): ReactNode {
 
           {/* Mobile Menu Button */}
           <button
+            data-testid="mobile-menu-button"
             className="rounded-md p-2 text-muted-foreground hover:bg-accent lg:hidden"
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
           >
@@ -91,7 +92,7 @@ export function Header(): ReactNode {
         <div
           className={cn(
             'overflow-hidden transition-all duration-200 lg:hidden',
-            mobileMenuOpen ? 'max-h-96 pb-4' : 'max-h-0',
+            mobileMenuOpen ? 'max-h-[600px] pb-4' : 'max-h-0',
           )}
         >
           <nav className="flex flex-col gap-2 pt-2">
@@ -143,8 +144,8 @@ export function Header(): ReactNode {
             <SearchBar />
             <div className="flex items-center gap-3">
               <ThemeToggle />
-              <NetworkSelector />
             </div>
+            <NetworkSelector inline />
           </div>
         </div>
       </div>

--- a/src/components/common/NetworkSelector.tsx
+++ b/src/components/common/NetworkSelector.tsx
@@ -3,7 +3,11 @@ import { ChevronDown, X } from 'lucide-react';
 import { useNetwork } from '@/hooks';
 import { cn } from '@/lib/utils';
 
-export function NetworkSelector(): ReactNode {
+interface NetworkSelectorProps {
+  inline?: boolean;
+}
+
+export function NetworkSelector({ inline }: NetworkSelectorProps): ReactNode {
   const {
     network,
     setNetwork,
@@ -16,8 +20,9 @@ export function NetworkSelector(): ReactNode {
   const [inputValue, setInputValue] = useState(customEndpoint || '');
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // Close dropdown when clicking outside
+  // Close dropdown when clicking outside (not needed for inline mode)
   useEffect(() => {
+    if (inline) return;
     function handleClickOutside(event: MouseEvent): void {
       if (
         dropdownRef.current &&
@@ -29,7 +34,7 @@ export function NetworkSelector(): ReactNode {
     }
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  }, [inline]);
 
   const handleCustomSubmit = (e: React.FormEvent): void => {
     e.preventDefault();
@@ -53,6 +58,9 @@ export function NetworkSelector(): ReactNode {
   return (
     <div className="relative" ref={dropdownRef}>
       <button
+        data-testid={
+          inline ? 'mobile-network-selector' : 'desktop-network-selector'
+        }
         className="inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-accent"
         onClick={() => setIsOpen(!isOpen)}
       >
@@ -69,7 +77,14 @@ export function NetworkSelector(): ReactNode {
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 top-full z-50 mt-2 min-w-[280px] rounded-md border border-border bg-popover p-1 shadow-lg">
+        <div
+          className={cn(
+            'rounded-md border border-border bg-popover p-1',
+            inline
+              ? 'mt-2'
+              : 'absolute right-0 top-full z-50 mt-2 min-w-[280px] shadow-lg',
+          )}
+        >
           {availableNetworks.map(net => (
             <button
               key={net.id}


### PR DESCRIPTION
  NetworkSelector dropdown was invisible on mobile because the mobile
  menu container uses overflow-hidden for slide animation, which clips
  absolutely positioned children.

  Fix: add inline prop to NetworkSelector that renders the network list
  inline (no absolute positioning) when inside the mobile menu. Desktop
  dropdown behavior unchanged.

  Also adds 2 mobile viewport e2e tests verifying the network selector
  is accessible and functional at 375px width.