### PR TITLE
fix: block state hash links and search work for all blocks

### DIFF
--- a/src/components/blocks/BlockList.tsx
+++ b/src/components/blocks/BlockList.tsx
@@ -79,7 +79,11 @@ export function BlockList({
                 </div>
               </td>
               <td className="px-4 py-3">
-                <HashLink hash={block.stateHash} type="block" />
+                <HashLink
+                  hash={block.stateHash}
+                  type="block"
+                  linkTo={`/block/${block.blockHeight}`}
+                />
               </td>
               <td className="px-4 py-3">
                 <HashLink hash={block.creator} type="account" />

--- a/src/components/common/HashLink.tsx
+++ b/src/components/common/HashLink.tsx
@@ -7,6 +7,8 @@ import { cn } from '@/lib/utils';
 interface HashLinkProps {
   hash: string;
   type: 'block' | 'transaction' | 'account';
+  /** Override the link target (e.g., use block height instead of hash) */
+  linkTo?: string;
   truncate?: boolean;
   prefixLength?: number;
   showCopy?: boolean;
@@ -15,6 +17,7 @@ interface HashLinkProps {
 export function HashLink({
   hash,
   type,
+  linkTo,
   truncate = true,
   prefixLength = 8,
   showCopy = true,
@@ -26,6 +29,8 @@ export function HashLink({
     transaction: `/tx/${hash}`,
     account: `/account/${hash}`,
   };
+
+  const linkPath = linkTo || pathMap[type];
 
   const displayText =
     truncate && type === 'account'
@@ -48,10 +53,7 @@ export function HashLink({
 
   return (
     <span className="inline-flex items-center gap-1">
-      <Link
-        to={pathMap[type]}
-        className="font-mono text-primary hover:underline"
-      >
+      <Link to={linkPath} className="font-mono text-primary hover:underline">
         {displayText}
       </Link>
       {showCopy && (

--- a/src/services/api/blocks.ts
+++ b/src/services/api/blocks.ts
@@ -773,39 +773,63 @@ export async function fetchBlockByHeight(
   return block;
 }
 
+const BLOCKS_HASH_SEARCH_QUERY = `
+  query SearchBlockByHash($limit: Int!) {
+    blocks(limit: $limit, sortBy: BLOCKHEIGHT_DESC) {
+      blockHeight
+      stateHash
+    }
+  }
+`;
+
+const BLOCKS_HASH_SEARCH_QUERY_PAGINATED = `
+  query SearchBlockByHashPaginated($limit: Int!, $maxBlockHeight: Int!) {
+    blocks(query: { blockHeight_lt: $maxBlockHeight }, limit: $limit, sortBy: BLOCKHEIGHT_DESC) {
+      blockHeight
+      stateHash
+    }
+  }
+`;
+
+interface HashSearchResponse {
+  blocks: Array<{ blockHeight: number; stateHash: string }>;
+}
+
 export async function fetchBlockByHash(
   stateHash: string,
 ): Promise<BlockDetail | null> {
-  // The API doesn't support querying by stateHash directly
-  // We need to search through recent blocks to find the height, then fetch details
   const client = getClient();
+  const CHUNK_SIZE = 500;
+  const MAX_CHUNKS = 10;
 
-  let data: BlocksResponse;
-  try {
-    data = await client.query<BlocksResponse>(BLOCKS_QUERY_FULL, {
-      limit: 100,
-    });
-  } catch {
-    // Fallback to basic query
-    try {
-      data = await client.query<BlocksResponse>(BLOCKS_QUERY_BASIC, {
-        limit: 100,
-      });
-    } catch {
-      // Fallback to minimal query (mainnet doesn't support userCommands/zkappCommands)
-      data = await client.query<BlocksResponse>(BLOCKS_QUERY_MINIMAL, {
-        limit: 100,
-      });
+  let cursor: number | undefined;
+
+  for (let i = 0; i < MAX_CHUNKS; i++) {
+    const query = cursor
+      ? BLOCKS_HASH_SEARCH_QUERY_PAGINATED
+      : BLOCKS_HASH_SEARCH_QUERY;
+    const variables: Record<string, unknown> = { limit: CHUNK_SIZE };
+    if (cursor) {
+      variables.maxBlockHeight = cursor;
     }
+
+    const data = await client.query<HashSearchResponse>(query, variables);
+
+    const match = data.blocks.find(b => b.stateHash === stateHash);
+    if (match) {
+      return fetchBlockByHeight(match.blockHeight);
+    }
+
+    // No more blocks to search
+    if (data.blocks.length < CHUNK_SIZE) {
+      break;
+    }
+
+    // Move cursor to oldest block in this chunk
+    cursor = data.blocks[data.blocks.length - 1].blockHeight;
   }
 
-  const block = data.blocks.find(b => b.stateHash === stateHash);
-  if (!block) {
-    return null;
-  }
-
-  // Fetch full block details by height
-  return fetchBlockByHeight(block.blockHeight);
+  return null;
 }
 
 export async function fetchNetworkState(): Promise<NetworkState> {


### PR DESCRIPTION
  - Block listing: state hash links navigate to /block/{height} instead of /block/{stateHash} for reliable navigation on all blocks
  - Search: fetchBlockByHash() now searches in chunks of 500 blocks (up to 5,000 deep) instead of only the last 100, enabling state hash search for old blocks
  - HashLink: new linkTo prop to override navigation target while preserving the displayed hash and copy functionality