### PR TITLE
feat: add development disclaimer banner and Minascan explorer links

### DIFF
--- a/src/components/common/Disclaimer.tsx
+++ b/src/components/common/Disclaimer.tsx
@@ -1,0 +1,57 @@
+import { type ReactNode, useState } from 'react';
+
+const DISMISSED_KEY = 'mina-explorer-disclaimer-dismissed';
+
+export function Disclaimer(): ReactNode {
+  const [dismissed, setDismissed] = useState(
+    () => localStorage.getItem(DISMISSED_KEY) === 'true',
+  );
+
+  if (dismissed) return null;
+
+  return (
+    <div className="border-b border-warning/30 bg-warning/10 px-4 py-3 text-sm text-foreground">
+      <div className="container mx-auto flex items-start justify-between gap-4">
+        <div>
+          <p>
+            <strong>Note:</strong> This explorer is an active development
+            project. Uptime and API availability are not currently guaranteed.
+          </p>
+          <p className="mt-1 text-muted-foreground">
+            If you&apos;re building production services or integrations that
+            require reliable API access, please use established third-party
+            explorers like{' '}
+            <a
+              href="https://minascan.io/mainnet/home"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium underline hover:text-foreground"
+            >
+              Minascan
+            </a>
+            . Found a bug or have feedback?{' '}
+            <a
+              href="https://github.com/o1-labs/mina-explorer/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium underline hover:text-foreground"
+            >
+              Open an issue on GitHub
+            </a>
+            .
+          </p>
+        </div>
+        <button
+          onClick={() => {
+            localStorage.setItem(DISMISSED_KEY, 'true');
+            setDismissed(true);
+          }}
+          className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+          aria-label="Dismiss disclaimer"
+        >
+          &#x2715;
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -1,12 +1,14 @@
 import type { ReactNode } from 'react';
 import { Outlet } from 'react-router-dom';
 import { Header } from './Header';
+import { Disclaimer } from './Disclaimer';
 import { Footer } from './Footer';
 
 export function Layout(): ReactNode {
   return (
     <div className="flex min-h-screen flex-col bg-background text-foreground">
       <Header />
+      <Disclaimer />
       <main className="container mx-auto grow px-4 py-6">
         <Outlet />
       </main>

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,6 +1,7 @@
 export { Layout } from './Layout';
 export { Header } from './Header';
 export { Footer } from './Footer';
+export { Disclaimer } from './Disclaimer';
 export { SearchBar } from './SearchBar';
 export { NetworkSelector } from './NetworkSelector';
 export { ThemeToggle } from './ThemeToggle';

--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -50,6 +50,12 @@ export const NETWORKS: Record<string, NetworkConfig> = {
     archiveEndpoint: 'https://devnet-archive-node-api.gcp.o1test.net',
     daemonEndpoint: 'https://devnet-plain-1.gcp.o1test.net/graphql',
     isTestnet: true,
+    otherExplorers: [
+      {
+        name: 'Minascan',
+        url: 'https://minascan.io/devnet/home',
+      },
+    ],
   },
   mainnet: {
     id: 'mainnet',
@@ -58,6 +64,12 @@ export const NETWORKS: Record<string, NetworkConfig> = {
     archiveEndpoint: 'https://archive-node-api.gcp.o1test.net',
     daemonEndpoint: 'https://mainnet-plain-1.gcp.o1test.net/graphql',
     isTestnet: false,
+    otherExplorers: [
+      {
+        name: 'Minascan',
+        url: 'https://minascan.io/mainnet/home',
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
  Add a dismissable disclaimer banner below the header noting that the
  explorer is under active development with no uptime guarantees, linking
  to Minascan and GitHub issues. Add Minascan as an other explorer for
  devnet and mainnet networks in the footer.