### PR TITLE
feat: encode selected network in shared URLs (#44)

### DIFF
--- a/e2e/explorer.spec.ts
+++ b/e2e/explorer.spec.ts
@@ -215,9 +215,10 @@ test.describe('Mina Explorer', () => {
     await page.locator('nav a:has-text("Blocks")').first().click();
     await expect(page).toHaveURL(/\/blocks/);
 
-    // Click on logo to go back home
+    // Click on logo to go back home. The URL sync effect re-appends
+    // ?network=<id> after navigation, so the route may end with a query string.
     await page.locator('header a').first().click();
-    await expect(page).toHaveURL(/\/#?\/?$/);
+    await expect(page).toHaveURL(/\/#\/?(\?network=[^/]+)?$/);
   });
 
   test('404 page for invalid routes', async ({ page }) => {

--- a/e2e/url-network-param.spec.ts
+++ b/e2e/url-network-param.spec.ts
@@ -1,0 +1,190 @@
+import { test, expect } from './fixtures';
+
+/**
+ * Tests for the `?network=<id>` URL parameter that encodes network selection
+ * into shared links (issue #44). The contract under test:
+ *
+ *   1. URL `?network=` takes precedence over localStorage on initial load.
+ *   2. Internal navigation always preserves the param (sync effect re-adds it
+ *      after any <Link> click that dropped it).
+ *   3. The URL-derived network does NOT overwrite localStorage — localStorage
+ *      remains the "default for new sessions".
+ *   4. Manual network selection (selector UI) updates BOTH the URL and
+ *      localStorage.
+ *   5. Invalid `?network=` values fall back gracefully without crashing.
+ *   6. A pre-existing custom endpoint still wins over `?network=` and the
+ *      stale param is stripped from the URL.
+ */
+
+const NETWORK_KEY = 'mina-explorer-network';
+const CUSTOM_KEY = 'mina-explorer-custom-endpoint';
+
+function networkParam(url: string): string | null {
+  const qIdx = url.indexOf('?');
+  if (qIdx < 0) return null;
+  return new URLSearchParams(url.slice(qIdx + 1)).get('network');
+}
+
+test.describe('URL ?network= parameter', () => {
+  test.beforeEach(async ({ page }) => {
+    // Start from a clean slate so localStorage from a previous test can't
+    // bleed into this one.
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.clear();
+    });
+  });
+
+  test('auto-adds ?network= when missing on first visit', async ({ page }) => {
+    // No localStorage, no URL param → falls back to DEFAULT_NETWORK ('mesa')
+    // and the sync effect should write it back to the URL.
+    await page.goto('/#/blocks');
+
+    await expect
+      .poll(() => networkParam(page.url()), { timeout: 5000 })
+      .toBe('mesa');
+  });
+
+  test('URL ?network= overrides localStorage on initial load', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.evaluate(
+      ([key, value]) => localStorage.setItem(key, value),
+      [NETWORK_KEY, 'mesa'],
+    );
+
+    await page.goto('/#/blocks?network=mainnet');
+
+    // Header should reflect Mainnet, not Mesa.
+    await expect(
+      page.locator('header button').filter({ hasText: 'Mainnet' }).first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    // URL still carries the override.
+    expect(networkParam(page.url())).toBe('mainnet');
+  });
+
+  test('URL-derived network does not overwrite localStorage', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.evaluate(
+      ([key, value]) => localStorage.setItem(key, value),
+      [NETWORK_KEY, 'mesa'],
+    );
+
+    await page.goto('/#/blocks?network=mainnet');
+    await expect(
+      page.locator('header button').filter({ hasText: 'Mainnet' }).first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    // localStorage MUST still hold the user's saved preference.
+    const stored = await page.evaluate(
+      key => localStorage.getItem(key),
+      NETWORK_KEY,
+    );
+    expect(stored).toBe('mesa');
+  });
+
+  test('network selector updates both URL param and localStorage', async ({
+    page,
+  }) => {
+    await page.goto('/#/blocks?network=mesa');
+    await expect(
+      page.locator('header button').filter({ hasText: 'Mesa' }).first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Open the selector and pick Devnet.
+    const networkButton = page
+      .locator('header button')
+      .filter({ hasText: /Pre-Mesa|Mesa|Devnet|Mainnet/ })
+      .first();
+    await networkButton.click();
+    await page.locator('button:has-text("Devnet")').first().click();
+
+    await expect(
+      page.locator('header button').filter({ hasText: 'Devnet' }).first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    // URL should be rewritten to ?network=devnet.
+    await expect
+      .poll(() => networkParam(page.url()), { timeout: 5000 })
+      .toBe('devnet');
+
+    // localStorage should also persist the explicit choice.
+    const stored = await page.evaluate(
+      key => localStorage.getItem(key),
+      NETWORK_KEY,
+    );
+    expect(stored).toBe('devnet');
+  });
+
+  test('?network= survives internal navigation via <Link>', async ({
+    page,
+  }) => {
+    // This is the regression test for the original bug: clicking any link
+    // inside the app must not drop the network param. The fix relies on a
+    // single sync effect re-adding it after navigation, so no <Link> call
+    // site needs to know about it.
+    await page.goto('/#/blocks?network=mainnet');
+    await expect(
+      page.locator('header button').filter({ hasText: 'Mainnet' }).first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Click the first row's link (block height or hash).
+    const tableRows = page.locator('tbody tr');
+    await expect(tableRows.first()).toBeVisible({ timeout: 15000 });
+    await tableRows.first().locator('a').first().click();
+
+    // We should land on a /block/... route and the param must still be there.
+    await expect
+      .poll(() => page.url(), { timeout: 5000 })
+      .toMatch(/#\/block\/[^?]+\?.*network=mainnet/);
+  });
+
+  test('invalid ?network= value falls back gracefully', async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(
+      ([key, value]) => localStorage.setItem(key, value),
+      [NETWORK_KEY, 'devnet'],
+    );
+
+    await page.goto('/#/blocks?network=not-a-real-network');
+
+    // Header should fall back to the localStorage value, not crash.
+    await expect(
+      page.locator('header button').filter({ hasText: 'Devnet' }).first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Sync effect should rewrite the URL to a valid id.
+    await expect
+      .poll(() => networkParam(page.url()), { timeout: 5000 })
+      .toBe('devnet');
+  });
+
+  test('custom endpoint wins over ?network= and strips the param', async ({
+    page,
+  }) => {
+    // Pre-seed a custom endpoint, then visit a shared link with ?network=.
+    // The custom endpoint should remain active and the stale param should
+    // be removed from the URL.
+    await page.goto('/');
+    await page.evaluate(
+      ([key, value]) => localStorage.setItem(key, value),
+      [CUSTOM_KEY, 'http://localhost:9999/graphql'],
+    );
+
+    await page.goto('/#/blocks?network=mainnet');
+
+    // Header should reflect "Custom", not Mainnet.
+    await expect(
+      page.locator('header button').filter({ hasText: 'Custom' }).first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    // URL ?network= should be stripped by the sync effect.
+    await expect
+      .poll(() => networkParam(page.url()), { timeout: 5000 })
+      .toBeNull();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,8 +20,8 @@ import {
 export function App(): ReactNode {
   return (
     <ThemeProvider>
-      <NetworkProvider>
-        <HashRouter>
+      <HashRouter>
+        <NetworkProvider>
           <Routes>
             <Route path="/" element={<Layout />}>
               <Route index element={<HomePage />} />
@@ -41,8 +41,8 @@ export function App(): ReactNode {
               <Route path="*" element={<NotFoundPage />} />
             </Route>
           </Routes>
-        </HashRouter>
-      </NetworkProvider>
+        </NetworkProvider>
+      </HashRouter>
     </ThemeProvider>
   );
 }

--- a/src/config/activeNetwork.ts
+++ b/src/config/activeNetwork.ts
@@ -1,0 +1,44 @@
+import { NETWORKS, DEFAULT_NETWORK } from './networks';
+
+const NETWORK_KEY = 'mina-explorer-network';
+const NETWORK_PARAM = 'network';
+
+/**
+ * Parse `?network=<id>` from `window.location.hash` (HashRouter URLs look
+ * like `#/block/10?network=mainnet`). Returns the id only if it matches a
+ * known network in NETWORKS, otherwise null.
+ *
+ * Used at module-load time, before React Router is mounted.
+ */
+export function getActiveNetworkIdFromHash(): string | null {
+  if (typeof window === 'undefined') return null;
+  const hash = window.location.hash;
+  const qIdx = hash.indexOf('?');
+  if (qIdx < 0) return null;
+  const params = new URLSearchParams(hash.slice(qIdx + 1));
+  const id = params.get(NETWORK_PARAM);
+  if (id && NETWORKS[id]) return id;
+  return null;
+}
+
+/**
+ * Resolve the active network id with the precedence:
+ *   1. `?network=<id>` query param in the URL hash
+ *   2. `localStorage['mina-explorer-network']`
+ *   3. DEFAULT_NETWORK
+ *
+ * Note: this helper deliberately does NOT consult the
+ * `mina-explorer-custom-endpoint` localStorage entry — callers that need to
+ * honour a custom endpoint must check it themselves before calling this.
+ */
+export function resolveActiveNetworkId(): string {
+  const fromUrl = getActiveNetworkIdFromHash();
+  if (fromUrl) return fromUrl;
+
+  if (typeof window !== 'undefined') {
+    const saved = window.localStorage.getItem(NETWORK_KEY);
+    if (saved && NETWORKS[saved]) return saved;
+  }
+
+  return DEFAULT_NETWORK;
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -9,3 +9,7 @@ export const config = {
 
 export { NETWORKS, DEFAULT_NETWORK } from './networks';
 export type { NetworkConfig, ExplorerLink } from './networks';
+export {
+  getActiveNetworkIdFromHash,
+  resolveActiveNetworkId,
+} from './activeNetwork';

--- a/src/context/NetworkContext.tsx
+++ b/src/context/NetworkContext.tsx
@@ -1,9 +1,22 @@
-import { createContext, useContext, useState, type ReactNode } from 'react';
-import { NETWORKS, DEFAULT_NETWORK, type NetworkConfig } from '@/config';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  NETWORKS,
+  DEFAULT_NETWORK,
+  resolveActiveNetworkId,
+  type NetworkConfig,
+} from '@/config';
 import { initClient, getClient } from '@/services/api';
 
 const CUSTOM_ENDPOINT_KEY = 'mina-explorer-custom-endpoint';
 const NETWORK_KEY = 'mina-explorer-network';
+const NETWORK_PARAM = 'network';
 
 interface NetworkContextValue {
   network: NetworkConfig;
@@ -19,7 +32,7 @@ function getInitialEndpoint(): {
   network: NetworkConfig;
   customEndpoint: string | null;
 } {
-  // Check for custom endpoint first
+  // Custom endpoint always wins — it's an explicit local override.
   const savedCustom = localStorage.getItem(CUSTOM_ENDPOINT_KEY);
   if (savedCustom) {
     return {
@@ -35,17 +48,10 @@ function getInitialEndpoint(): {
     };
   }
 
-  // Check for saved network selection
-  const savedNetwork = localStorage.getItem(NETWORK_KEY);
-  if (savedNetwork && NETWORKS[savedNetwork]) {
-    return {
-      network: NETWORKS[savedNetwork],
-      customEndpoint: null,
-    };
-  }
-
+  // Otherwise resolve via shared precedence: URL hash → localStorage → default.
+  const networkId = resolveActiveNetworkId();
   return {
-    network: NETWORKS[DEFAULT_NETWORK],
+    network: NETWORKS[networkId],
     customEndpoint: null,
   };
 }
@@ -63,6 +69,44 @@ export function NetworkProvider({ children }: NetworkProviderProps): ReactNode {
   const [customEndpoint, setCustomEndpointState] = useState<string | null>(
     initial.customEndpoint,
   );
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Keep `?network=<id>` in the URL in sync with the active network so that
+  // shared/copied URLs always carry network context.
+  //
+  // - If the URL has no `network` param, we add the current one (replace, no
+  //   history entry) so any internal navigation re-acquires it immediately.
+  // - If the URL has a valid `network` param that differs from the current
+  //   state (e.g. user pasted a shared link, or hit back/forward), we adopt
+  //   it without writing localStorage — the URL is treated as session-scoped.
+  // - Custom endpoints have no shareable id; strip any stale param so the URL
+  //   reflects the actual state.
+  useEffect(() => {
+    if (customEndpoint) {
+      if (searchParams.has(NETWORK_PARAM)) {
+        const next = new URLSearchParams(searchParams);
+        next.delete(NETWORK_PARAM);
+        setSearchParams(next, { replace: true });
+      }
+      return;
+    }
+
+    const urlId = searchParams.get(NETWORK_PARAM);
+
+    if (urlId && NETWORKS[urlId]) {
+      if (urlId !== network.id) {
+        const newNetwork = NETWORKS[urlId];
+        setNetworkState(newNetwork);
+        getClient().setEndpoint(newNetwork.archiveEndpoint);
+      }
+      return;
+    }
+
+    // No (or invalid) network param in URL — write the current one back.
+    const next = new URLSearchParams(searchParams);
+    next.set(NETWORK_PARAM, network.id);
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams, network.id, customEndpoint]);
 
   const setNetwork = (networkId: string): void => {
     const newNetwork = NETWORKS[networkId];
@@ -72,6 +116,9 @@ export function NetworkProvider({ children }: NetworkProviderProps): ReactNode {
       localStorage.removeItem(CUSTOM_ENDPOINT_KEY);
       localStorage.setItem(NETWORK_KEY, networkId);
       getClient().setEndpoint(newNetwork.archiveEndpoint);
+      const next = new URLSearchParams(searchParams);
+      next.set(NETWORK_PARAM, networkId);
+      setSearchParams(next, { replace: true });
     }
   };
 
@@ -89,6 +136,10 @@ export function NetworkProvider({ children }: NetworkProviderProps): ReactNode {
       setCustomEndpointState(endpoint);
       localStorage.setItem(CUSTOM_ENDPOINT_KEY, endpoint);
       getClient().setEndpoint(endpoint);
+      // Drop any stale `network` param — it doesn't apply to custom endpoints.
+      const next = new URLSearchParams(searchParams);
+      next.delete(NETWORK_PARAM);
+      setSearchParams(next, { replace: true });
     } else {
       setCustomEndpointState(null);
       localStorage.removeItem(CUSTOM_ENDPOINT_KEY);

--- a/src/services/api/accounts.ts
+++ b/src/services/api/accounts.ts
@@ -1,13 +1,8 @@
 import type { Account } from '@/types';
-import { NETWORKS, DEFAULT_NETWORK } from '@/config';
-
-const NETWORK_KEY = 'mina-explorer-network';
+import { NETWORKS, resolveActiveNetworkId } from '@/config';
 
 function getDaemonEndpoint(): string {
-  const savedNetwork = localStorage.getItem(NETWORK_KEY);
-  const networkId =
-    savedNetwork && NETWORKS[savedNetwork] ? savedNetwork : DEFAULT_NETWORK;
-  return NETWORKS[networkId].daemonEndpoint;
+  return NETWORKS[resolveActiveNetworkId()].daemonEndpoint;
 }
 
 // Daemon GraphQL query for account data

--- a/src/services/api/daemon.ts
+++ b/src/services/api/daemon.ts
@@ -1,12 +1,7 @@
-import { NETWORKS, DEFAULT_NETWORK } from '@/config';
-
-const NETWORK_KEY = 'mina-explorer-network';
+import { NETWORKS, resolveActiveNetworkId } from '@/config';
 
 export function getDaemonEndpoint(): string {
-  const savedNetwork = localStorage.getItem(NETWORK_KEY);
-  const networkId =
-    savedNetwork && NETWORKS[savedNetwork] ? savedNetwork : DEFAULT_NETWORK;
-  return NETWORKS[networkId].daemonEndpoint;
+  return NETWORKS[resolveActiveNetworkId()].daemonEndpoint;
 }
 
 interface GraphQLResponse<T> {


### PR DESCRIPTION
  Network selection was persisted only in localStorage, so a copied URL like
  `/#/block/10` would render the recipient's currently selected network rather
  than the sender's. Add a `?network=<id>` query param to the hash portion of
  every URL with the precedence `URL > localStorage > default`. `localStorage`
  remains the per-session default so user preferences still stick across new
  tabs.

  A single sync effect in NetworkContext re-adds the param after every
  navigation, so no `<Link>` or `useNavigate()` call site needs to change.
  `NetworkProvider` moves inside `HashRouter` so it can use `useSearchParams`.
  `daemon.ts` and `accounts.ts` now share a `resolveActiveNetworkId()` helper so
  all three endpoint-resolution paths agree on which network is active.

  Custom endpoint still wins over the URL param; the sync effect strips any
  stale `?network=` from the URL when a custom endpoint is active so the URL
  reflects actual state.

  Closes #44