### PR TITLE
ci: add automated releases with notes, tarball, and Slack notify

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# CODEOWNERS for mina-explorer
+#
+# Scope: only release-affecting paths are gated. The rest of the repo has
+# no required ownership so day-to-day PRs are not slowed down.
+#
+# Effective only when branch protection on `main` has
+# "Require review from Code Owners" enabled in repo settings.
+
+# Release plumbing
+/.github/workflows/deploy.yml @o1-labs/eng @sanabriarusso @amc-ie @dkijania @georgeeee
+/.github/release.yml          @o1-labs/eng @sanabriarusso @amc-ie @dkijania @georgeeee
+/.github/CODEOWNERS           @o1-labs/eng @sanabriarusso @amc-ie @dkijania @georgeeee
+
+# Release documentation
+/RELEASES.md                  @o1-labs/eng @sanabriarusso @amc-ie @dkijania @georgeeee

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - dependabot[bot]
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Changes
+      labels:
+        - "*"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,21 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Custom tag (e.g., v1.0.0). Leave empty to use semver auto-bump from commit prefixes.'
+        required: false
+        type: string
+      prerelease:
+        description: 'Mark the release as a prerelease'
+        required: false
+        type: boolean
+        default: false
+      skip_release:
+        description: 'Deploy only — do not create a release'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -39,10 +54,17 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      - name: Upload artifact
+      - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:
           path: ./dist
+
+      - name: Upload dist for release
+        uses: actions/upload-artifact@v6
+        with:
+          name: dist
+          path: dist
+          retention-days: 7
 
   deploy:
     environment:
@@ -54,3 +76,301 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  release:
+    needs: [build, deploy]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      models: read
+    if: |
+      (github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip release]')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.skip_release != true)
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute tag (semver auto-bump)
+        id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # 1) Manual override wins.
+          if [[ -n "${INPUT_TAG:-}" ]]; then
+            TAG="$INPUT_TAG"
+            PREV=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1 || true)
+            echo "tag=$TAG"   >> "$GITHUB_OUTPUT"
+            echo "prev=$PREV" >> "$GITHUB_OUTPUT"
+            echo "bump=manual" >> "$GITHUB_OUTPUT"
+            echo "skip=false"  >> "$GITHUB_OUTPUT"
+            echo "Manual tag override: $TAG (previous: $PREV)"
+            exit 0
+          fi
+
+          # 2) Find latest semver tag (default v0.0.0 if none).
+          LAST=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1 || true)
+          if [[ -z "$LAST" ]]; then LAST="v0.0.0"; fi
+          MAJOR=$(echo "$LAST" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1/')
+          MINOR=$(echo "$LAST" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\2/')
+          PATCH=$(echo "$LAST" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\3/')
+
+          # 3) Walk commits since last semver tag.
+          if [[ "$LAST" == "v0.0.0" ]]; then
+            COMMITS=$(git log --pretty=format:'%s%n%b')
+          else
+            COMMITS=$(git log "${LAST}..HEAD" --pretty=format:'%s%n%b')
+          fi
+
+          if [[ -z "$COMMITS" ]]; then
+            echo "No new commits since $LAST — skipping release"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 4) Determine bump (highest precedence wins).
+          BUMP=patch
+          if echo "$COMMITS" | grep -qiE '(^|\s)(feat|fix|refactor|perf|build|chore|docs|style|test|ci)(\([^)]+\))?!:|BREAKING CHANGE'; then
+            BUMP=major
+          elif echo "$COMMITS" | grep -qiE '(^|\s)feat(\([^)]+\))?:'; then
+            BUMP=minor
+          elif echo "$COMMITS" | grep -qiE '(^|\s)fix(\([^)]+\))?:'; then
+            BUMP=patch
+          fi
+
+          case "$BUMP" in
+            major) NEW="v$((MAJOR+1)).0.0" ;;
+            minor) NEW="v${MAJOR}.$((MINOR+1)).0" ;;
+            patch) NEW="v${MAJOR}.${MINOR}.$((PATCH+1))" ;;
+          esac
+
+          echo "Last: $LAST  Bump: $BUMP  New: $NEW"
+          echo "tag=$NEW"   >> "$GITHUB_OUTPUT"
+          echo "prev=$LAST" >> "$GITHUB_OUTPUT"
+          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if tag already exists
+        id: exists
+        if: steps.tag.outputs.skip != 'true'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists — nothing to release"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.tag.outputs.skip != 'true' && steps.exists.outputs.skip != 'true'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
+      - name: Generate raw release notes
+        if: steps.tag.outputs.skip != 'true' && steps.exists.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          PREV: ${{ steps.tag.outputs.prev }}
+        run: |
+          set -euo pipefail
+          ARGS=(-X POST "/repos/${{ github.repository }}/releases/generate-notes"
+                -f "tag_name=${TAG}")
+          if [[ -n "${PREV:-}" ]]; then
+            ARGS+=(-f "previous_tag_name=${PREV}")
+          fi
+          gh api "${ARGS[@]}" --jq .body > raw-notes.md
+          echo "--- raw notes ---"
+          cat raw-notes.md
+
+      - name: Group notes by prefix (feat/fix/other)
+        if: steps.tag.outputs.skip != 'true' && steps.exists.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          BULLETS=$(grep -E '^\* ' raw-notes.md || true)
+          FEATURES=$(echo "$BULLETS" | grep -iE '^\* (feat|feature)[:(]' || true)
+          FIXES=$(echo   "$BULLETS" | grep -iE '^\* (fix|bugfix)[:(]'    || true)
+          OTHER=$(echo   "$BULLETS" | grep -ivE '^\* (feat|feature|fix|bugfix)[:(]' || true)
+          FULL_LINK=$(grep -E '^\*\*Full Changelog' raw-notes.md || true)
+
+          {
+            echo "## What's Changed"
+            echo
+            if [[ -n "$FEATURES" ]]; then echo "### Features";  echo "$FEATURES"; echo; fi
+            if [[ -n "$FIXES"    ]]; then echo "### Bug Fixes"; echo "$FIXES";    echo; fi
+            if [[ -n "$OTHER"    ]]; then echo "### Other";     echo "$OTHER";    echo; fi
+            [[ -n "$FULL_LINK" ]] && echo "$FULL_LINK"
+          } > release-notes.md
+          echo "--- grouped notes ---"
+          cat release-notes.md
+
+      - name: Pass notes to AI step via env
+        if: steps.tag.outputs.skip != 'true' && steps.exists.outputs.skip != 'true'
+        run: |
+          {
+            echo 'NOTES_FOR_AI<<RELEASE_NOTES_EOF'
+            cat release-notes.md
+            echo 'RELEASE_NOTES_EOF'
+          } >> "$GITHUB_ENV"
+
+      - name: AI narrative summary (free via GitHub Models)
+        if: steps.tag.outputs.skip != 'true' && steps.exists.outputs.skip != 'true'
+        continue-on-error: true
+        uses: actions/ai-inference@v2
+        id: ai
+        with:
+          model: openai/gpt-4o-mini
+          system-prompt: |
+            You write concise release announcements for the mina-explorer
+            blockchain explorer. Plain prose, 2-3 sentences, no headings,
+            no bullets, no markdown decoration. Audience is end users, not
+            developers. Lead with the most user-visible change.
+          prompt: |
+            Summarize what's new in this release based on these notes:
+
+            ${{ env.NOTES_FOR_AI }}
+
+      - name: Prepend AI summary to release notes
+        if: steps.tag.outputs.skip != 'true' && steps.exists.outputs.skip != 'true' && steps.ai.outputs.response != ''
+        env:
+          AI_SUMMARY: ${{ steps.ai.outputs.response }}
+        run: |
+          {
+            printf '%s\n\n' "$AI_SUMMARY"
+            cat release-notes.md
+          } > tmp && mv tmp release-notes.md
+          echo "--- final release notes ---"
+          cat release-notes.md
+
+      - name: Download dist artifact
+        if: steps.tag.outputs.skip != 'true' && steps.exists.outputs.skip != 'true'
+        uses: actions/download-artifact@v6
+        with:
+          name: dist
+          path: dist
+
+      - name: Package dist as tarball
+        if: steps.tag.outputs.skip != 'true' && steps.exists.outputs.skip != 'true'
+        id: pkg
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          TARBALL="mina-explorer-${TAG}.tar.gz"
+          tar -czf "$TARBALL" -C dist .
+          ls -lh "$TARBALL"
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        if: steps.tag.outputs.skip != 'true' && steps.exists.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          TARBALL: ${{ steps.pkg.outputs.tarball }}
+          PRERELEASE: ${{ inputs.prerelease }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [[ "${PRERELEASE:-false}" == "true" ]]; then PRERELEASE_FLAG="--prerelease"; fi
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file release-notes.md \
+            $PRERELEASE_FLAG \
+            "$TARBALL"
+
+      # ----- Slack announcement -----
+      # Path A: GCP Secret Manager fetch (preferred). Skipped if GCP_SLACK_TOKEN_SA_KEY is not set.
+      # Path B: direct GitHub repo secret (fallback). Used if SLACK_BOT_TOKEN is set and Path A didn't run.
+      # If neither secret is set, all Slack steps short-circuit and the release ships without notifying.
+
+      - name: Authenticate to GCP (Path A)
+        if: steps.tag.outputs.skip != 'true' && steps.exists.outputs.skip != 'true' && env.GCP_SA_KEY != ''
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_SLACK_TOKEN_SA_KEY }}
+        id: gcp_auth
+        continue-on-error: true
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SLACK_TOKEN_SA_KEY }}
+
+      - name: Fetch Slack bot token from GCP Secret Manager (Path A)
+        if: steps.gcp_auth.outcome == 'success'
+        id: gcp_secret
+        continue-on-error: true
+        uses: google-github-actions/get-secretmanager-secrets@v2
+        with:
+          secrets: |-
+            slack_bot_token:o1labs-192920/slackGrafanaAlertsBotToken
+
+      - name: Resolve Slack token (Path A or Path B)
+        if: steps.tag.outputs.skip != 'true' && steps.exists.outputs.skip != 'true'
+        id: slack_token
+        env:
+          PATH_A_TOKEN: ${{ steps.gcp_secret.outputs.slack_bot_token }}
+          PATH_B_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          if [[ -n "${PATH_A_TOKEN:-}" ]]; then
+            echo "Using Path A (GCP Secret Manager)"
+            TOKEN="$PATH_A_TOKEN"
+          elif [[ -n "${PATH_B_TOKEN:-}" ]]; then
+            echo "Using Path B (GitHub repo secret SLACK_BOT_TOKEN)"
+            TOKEN="$PATH_B_TOKEN"
+          else
+            echo "Neither GCP_SLACK_TOKEN_SA_KEY nor SLACK_BOT_TOKEN is set — skipping Slack notify"
+            echo "have_token=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::add-mask::$TOKEN"
+          echo "have_token=true" >> "$GITHUB_OUTPUT"
+          # Pass the token to subsequent steps via masked env, not as a step output.
+          {
+            echo 'SLACK_BOT_TOKEN<<SLACK_TOKEN_EOF'
+            echo "$TOKEN"
+            echo 'SLACK_TOKEN_EOF'
+          } >> "$GITHUB_ENV"
+
+      - name: Post release announcement to Slack
+        if: steps.tag.outputs.skip != 'true' && steps.exists.outputs.skip != 'true' && steps.slack_token.outputs.have_token == 'true'
+        continue-on-error: true
+        env:
+          # SLACK_BOT_TOKEN is exported by the previous step via $GITHUB_ENV.
+          # Channel + subteam mention match Grafana's slack-platform-eng contact point
+          # (see gitops-infrastructure/.../grafana/templates/extra-deploys.yaml.gotmpl L60-L62)
+          SLACK_CHANNEL: '#platform-eng-team'
+          SLACK_MENTION: '<!subteam^S04EBNWL4HG>'
+          TAG: ${{ steps.tag.outputs.tag }}
+          REPO: ${{ github.repository }}
+          AI_SUMMARY: ${{ steps.ai.outputs.response }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${AI_SUMMARY// }" ]]; then
+            SUMMARY="A new release of mina-explorer is out — see the link for details."
+          else
+            SUMMARY="$AI_SUMMARY"
+          fi
+
+          RELEASE_URL="https://github.com/${REPO}/releases/tag/${TAG}"
+          TEXT="${SLACK_MENTION} :package: *mina-explorer ${TAG}* released
+${SUMMARY}
+${RELEASE_URL}"
+
+          PAYLOAD=$(jq -nc \
+            --arg channel "$SLACK_CHANNEL" \
+            --arg text    "$TEXT" \
+            '{channel: $channel, text: $text, unfurl_links: true}')
+
+          RESP=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            -d "$PAYLOAD")
+          echo "$RESP" | jq .
+          echo "$RESP" | jq -e '.ok == true'

--- a/README.md
+++ b/README.md
@@ -126,11 +126,13 @@ npx playwright test e2e/explorer.spec.ts -g "test name pattern"
 TEST_DEPLOYED=true npx playwright test
 ```
 
-## Deployment
+## Releases & Deployment
 
-The explorer is deployed to GitHub Pages via CI on push to `main`. The base path is `/mina-explorer/` for the GitHub Pages subdirectory.
+Every push to `main` builds the explorer, deploys it to GitHub Pages, cuts a semver-bumped GitHub release with a downloadable build artifact, and posts an announcement to `#platform-eng-team`. The release tag is auto-bumped from conventional-commit prefixes (`feat:` → minor, `fix:` → patch, `feat!:` → major).
 
-The deploy workflow runs: typecheck → build → upload to GitHub Pages.
+To trigger a release manually or override the auto-tag, use **Actions → Deploy to GitHub Pages → Run workflow**. To skip a release on a particular push, include `[skip release]` in the commit message.
+
+See [`RELEASES.md`](RELEASES.md) for the full reference (commit prefix rules, self-hosting, manual override, Slack setup, CODEOWNERS gate).
 
 ## Contributing
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,94 @@
+# Releases
+
+`mina-explorer` cuts a release on **every push to `main`** and on **every manual run of the Deploy workflow**. Each release ships:
+
+- a semver-bumped git tag
+- a categorized changelog (Features / Bug Fixes / Other)
+- a 2–3 sentence AI-written summary at the top of the release notes
+- a downloadable build of the explorer (`mina-explorer-<tag>.tar.gz`)
+- a Slack announcement to `#platform-eng-team`
+
+## Versioning — automatic semver from commit prefixes
+
+The release workflow walks the commits between the last semver tag and `HEAD` and picks the bump from the highest-precedence prefix it finds:
+
+| Prefix in any commit                                       | Bump  | Example             |
+| ---------------------------------------------------------- | ----- | ------------------- |
+| `feat!:` / `fix!:` / any `(type)!:` / `BREAKING CHANGE`    | major | `v0.1.0` → `v1.0.0` |
+| `feat:` or `feat(scope):`                                  | minor | `v0.1.0` → `v0.2.0` |
+| `fix:` or `fix(scope):`                                    | patch | `v0.1.0` → `v0.1.1` |
+| anything else (e.g. `chore:`, `docs:`, no prefix)          | patch | `v0.1.0` → `v0.1.1` |
+
+If `HEAD` is already at the last release tag (no new commits) the release job exits cleanly without creating a duplicate tag.
+
+### Conventions
+
+- Use the prefix in the **PR title and squashed commit subject**, lower-case.
+- Optional scope in parens: `feat(blocks): paginate detail view`.
+- Use `!:` (e.g. `feat!:`, `fix(api)!:`) **or** include `BREAKING CHANGE` in the commit body for any user-visible breaking change.
+- The bump rule is intentionally permissive — pushes without any conventional prefix still produce a `patch` release. The fallback exists so trivial commits don't silently disappear from the release timeline.
+
+### Skipping a release for a particular push
+
+Include `[skip release]` anywhere in the head commit message. The deploy still runs; the release job exits early.
+
+### Manual release / milestone tag
+
+Go to **Actions → Deploy to GitHub Pages → Run workflow** and fill in:
+
+- `tag` — optional, e.g. `v1.0.0`. Overrides the auto-bump entirely.
+- `prerelease` — optional, marks the release as prerelease.
+- `skip_release` — optional, deploy only, no release.
+
+## What's in each release
+
+- **Tag** — `vMAJOR.MINOR.PATCH` (or whatever you passed to `tag`).
+- **Title** — the tag.
+- **Body** — AI-written 2–3 sentence summary, then a categorized changelog grouped as **Features / Bug Fixes / Other**, then a "Full Changelog" link to the GitHub diff view.
+- **Asset: `mina-explorer-<tag>.tar.gz`** — the production build of the explorer (`dist/`), ready to serve.
+- **Source code (zip + tar.gz)** — auto-attached by GitHub for users who want to build from source.
+
+## Self-hosting
+
+The explorer is a static SPA — any webserver works.
+
+```bash
+TAG=v0.2.0
+curl -L -O https://github.com/o1-labs/mina-explorer/releases/download/${TAG}/mina-explorer-${TAG}.tar.gz
+mkdir mina-explorer && tar -xzf mina-explorer-${TAG}.tar.gz -C mina-explorer
+# serve under /mina-explorer/ — see "Base path" below
+```
+
+### Base path
+
+The build hard-codes `base: '/mina-explorer/'` in `vite.config.ts` so it matches the GitHub Pages subdirectory. To self-host you have two options:
+
+1. **Serve under `/mina-explorer/`** (simplest). Example nginx:
+
+   ```nginx
+   location /mina-explorer/ {
+     alias /var/www/mina-explorer/;
+     try_files $uri $uri/ /mina-explorer/index.html;
+   }
+   ```
+
+2. **Rebuild from source** with a different base — clone the repo, edit `vite.config.ts` (`base: '/'`), `npx vite build`, serve the resulting `dist/` at root. Slightly more work but lets you serve the explorer directly at `/`.
+
+A pre-built Docker image is a planned future enhancement; it isn't shipped today because the hard-coded base path would need a second build configuration.
+
+## Slack notifications
+
+Each release posts a short announcement to `#platform-eng-team` with the `@platform-eng-all` mention. Channel and mention are the same ones used by the Grafana alerting setup in `gitops-infrastructure`.
+
+The bot token can be sourced two ways and the workflow accepts either:
+
+- **Path A (preferred):** the token is fetched at workflow runtime from the GCP secret `projects/o1labs-192920/secrets/slackGrafanaAlertsBotToken`, via a least-privilege service account whose JSON key is stored in the GitHub repo secret `GCP_SLACK_TOKEN_SA_KEY`. Token rotation in GCP propagates automatically.
+- **Path B (fallback):** the token is copied once into the GitHub repo secret `SLACK_BOT_TOKEN`. Simpler, but rotation no longer propagates automatically — re-run the manual copy step when the GCP secret is rotated.
+
+If neither secret is set, the release ships without sending a Slack notification.
+
+## CODEOWNERS
+
+Changes to `.github/workflows/deploy.yml`, `.github/release.yml`, `.github/CODEOWNERS`, and `RELEASES.md` require approval from a member of `@o1-labs/eng` or one of: @sanabriarusso, @amc-ie, @dkijania, @georgeeee. This gate exists so a stray PR can't accidentally change how releases are cut, signed, or announced.
+
+The CODEOWNERS file is only enforced when branch protection on `main` has **"Require review from Code Owners"** enabled in repo settings.


### PR DESCRIPTION
  Cut a GitHub release on every push to main and on manual workflow_dispatch.
  The release tag is auto-bumped from conventional-commit prefixes (feat:
  minor, fix: patch, ! or BREAKING CHANGE: major; patch fallback for
  non-conventional pushes). [skip release] opts out, and workflow_dispatch
  accepts a tag input that overrides the auto-bump.

  Each release includes a categorized changelog (Features / Bug Fixes /
  Other), a 2-3 sentence AI summary via free GitHub Models, a
  mina-explorer-<tag>.tar.gz of the built dist, and a Slack announcement to
  #platform-eng-team mentioning @platform-eng-all. The Slack bot token is
  fetched at runtime from GCP Secret Manager (slackGrafanaAlertsBotToken,
  same source Grafana alerts use), with a SLACK_BOT_TOKEN GitHub secret
  fallback.

  Add CODEOWNERS gating @o1-labs/eng on the release plumbing files and a
  new RELEASES.md documenting commit conventions, self-hosting, and the
  Slack/CODEOWNERS setup.