### PR TITLE
fix(ci): correct YAML literal block in Slack notify step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -359,9 +359,8 @@ jobs:
           fi
 
           RELEASE_URL="https://github.com/${REPO}/releases/tag/${TAG}"
-          TEXT="${SLACK_MENTION} :package: *mina-explorer ${TAG}* released
-${SUMMARY}
-${RELEASE_URL}"
+          TEXT=$(printf '%s :package: *mina-explorer %s* released\n%s\n%s' \
+            "$SLACK_MENTION" "$TAG" "$SUMMARY" "$RELEASE_URL")
 
           PAYLOAD=$(jq -nc \
             --arg channel "$SLACK_CHANNEL" \


### PR DESCRIPTION
  The Slack TEXT value was built with a multi-line bash assignment whose
  embedded newlines broke the YAML literal block scalar (lines started at
  column 0 instead of the bash block's indentation), causing
  'Invalid workflow file' on parse. Replace the multi-line string with a
  single-line printf so the YAML stays intact.