### PR TITLE
feat: broadcast pre-signed transactions (#53)

### DIFF
--- a/e2e/broadcast.spec.ts
+++ b/e2e/broadcast.spec.ts
@@ -1,0 +1,339 @@
+import { test, expect, FIXTURES } from './fixtures';
+
+// Cryptographically valid payment with field/scalar signature (for validation tests)
+const VERIFIABLE_PAYMENT_JSON = JSON.stringify({
+  input: {
+    to: 'B62qqL54NrFkuiBf3YQHm6g5VAP7qgC3PRiJRGoiAf4sMR1Liu2Z99U',
+    from: 'B62qqL54NrFkuiBf3YQHm6g5VAP7qgC3PRiJRGoiAf4sMR1Liu2Z99U',
+    fee: '10000000',
+    amount: '1000000000',
+    nonce: '0',
+    memo: '',
+    validUntil: '4294967295',
+  },
+  signature: {
+    field:
+      '7545941374414503936865922080778019681378514718481296414877447758616852124931',
+    scalar:
+      '27128786267821164944622931800480400730131280358175515211996102746209373634042',
+  },
+});
+
+const VALID_PAYMENT_JSON = JSON.stringify({
+  input: {
+    from: FIXTURES.accounts.blockProducer,
+    to: FIXTURES.accounts.knownAccount,
+    amount: '1000000000',
+    fee: '10000000',
+  },
+  signature: {
+    rawSignature:
+      '7mXGz1VE9kntMCrzfBVBiJoypbgPGRCDNdXUFGJZSoCCgFJMLM7v9WGxW37osBFN3JALD8AhxBpbmcqYsBqvmJvY7sandP',
+  },
+});
+
+const VALID_DELEGATION_JSON = JSON.stringify({
+  input: {
+    from: FIXTURES.accounts.blockProducer,
+    to: FIXTURES.accounts.knownAccount,
+    fee: '10000000',
+  },
+  signature: {
+    rawSignature:
+      '7mXGz1VE9kntMCrzfBVBiJoypbgPGRCDNdXUFGJZSoCCgFJMLM7v9WGxW37osBFN3JALD8AhxBpbmcqYsBqvmJvY7sandP',
+  },
+});
+
+const VALID_ZKAPP_JSON = JSON.stringify({
+  input: {
+    zkappCommand: {
+      feePayer: {
+        body: { publicKey: FIXTURES.accounts.blockProducer, fee: '10000000' },
+      },
+      accountUpdates: [],
+      memo: 'E4Yd...',
+    },
+  },
+});
+
+test.describe('Broadcast Transaction', () => {
+  test('page loads correctly', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    await expect(page.locator('h1')).toHaveText('Broadcast Transaction');
+    await expect(page.locator('textarea')).toBeVisible();
+
+    // Type selector tabs are present
+    await expect(page.getByRole('button', { name: 'Payment' })).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Delegation' }),
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'zkApp' })).toBeVisible();
+
+    // Security notice is visible
+    await expect(page.locator('text=pre-signed transactions')).toBeVisible();
+  });
+
+  test('navigation link works', async ({ page }) => {
+    await page.goto('/');
+
+    // Click Broadcast in nav
+    await page.locator('nav a[href="#/broadcast"]').first().click();
+    await expect(page).toHaveURL(/.*#\/broadcast/);
+    await expect(page.locator('h1')).toHaveText('Broadcast Transaction');
+  });
+
+  test('type selector switches example template', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    // Show example
+    await page.getByText('Example JSON').click();
+    await expect(page.locator('pre')).toContainText('"amount"');
+
+    // Switch to Delegation
+    await page.getByRole('button', { name: 'Delegation' }).click();
+    await expect(page.locator('pre')).not.toContainText('"amount"');
+
+    // Switch to zkApp
+    await page.getByRole('button', { name: 'zkApp' }).click();
+    await expect(page.locator('pre')).toContainText('"zkappCommand"');
+  });
+
+  test('shows error for invalid JSON', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    await page.locator('textarea').fill('{bad json');
+    await page
+      .getByRole('button', { name: 'Broadcast Transaction' })
+      .click();
+
+    await expect(page.locator('text=Invalid JSON')).toBeVisible();
+  });
+
+  test('shows error for missing required fields', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    // Payment without amount
+    await page.locator('textarea').fill(
+      JSON.stringify({
+        input: {
+          from: FIXTURES.accounts.blockProducer,
+          to: FIXTURES.accounts.knownAccount,
+          fee: '10000000',
+        },
+        signature: { rawSignature: 'test' },
+      }),
+    );
+    await page
+      .getByRole('button', { name: 'Broadcast Transaction' })
+      .click();
+
+    await expect(page.locator('text=Missing required field')).toBeVisible();
+  });
+
+  test('shows error for missing signature', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    await page.locator('textarea').fill(
+      JSON.stringify({
+        input: {
+          from: FIXTURES.accounts.blockProducer,
+          to: FIXTURES.accounts.knownAccount,
+          amount: '1000000000',
+          fee: '10000000',
+        },
+      }),
+    );
+    await page
+      .getByRole('button', { name: 'Broadcast Transaction' })
+      .click();
+
+    await expect(
+      page.getByText('Missing "signature" object'),
+    ).toBeVisible();
+  });
+
+  test('broadcasts payment successfully', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    await page.locator('textarea').fill(VALID_PAYMENT_JSON);
+    await page
+      .getByRole('button', { name: 'Broadcast Transaction' })
+      .click();
+
+    await expect(
+      page.locator('text=Transaction broadcast successfully'),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=CkpMockPaymentHash')).toBeVisible();
+  });
+
+  test('broadcasts delegation successfully', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    await page.getByRole('button', { name: 'Delegation' }).click();
+    await page.locator('textarea').fill(VALID_DELEGATION_JSON);
+    await page
+      .getByRole('button', { name: 'Broadcast Transaction' })
+      .click();
+
+    await expect(
+      page.locator('text=Transaction broadcast successfully'),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=CkpMockDelegationHash')).toBeVisible();
+  });
+
+  test('broadcasts zkApp successfully', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    await page.getByRole('button', { name: 'zkApp' }).click();
+    await page.locator('textarea').fill(VALID_ZKAPP_JSON);
+    await page
+      .getByRole('button', { name: 'Broadcast Transaction' })
+      .click();
+
+    await expect(
+      page.locator('text=Transaction broadcast successfully'),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=CkpMockZkAppHash')).toBeVisible();
+  });
+
+  test('signing docs section toggles', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    const toggle = page.getByText('How to sign a transaction');
+    await expect(toggle).toBeVisible();
+
+    // Initially collapsed
+    await expect(page.locator('text=mina-signer')).not.toBeVisible();
+
+    // Expand
+    await toggle.click();
+    await expect(
+      page.getByText('npm install mina-signer'),
+    ).toBeVisible();
+    await expect(page.getByText('dump-keypair')).toBeVisible();
+
+    // Collapse
+    await toggle.click();
+    await expect(page.getByText('dump-keypair')).not.toBeVisible();
+  });
+
+  test('validate button is visible', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    await expect(
+      page.getByRole('button', { name: 'Validate Signature' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Broadcast Transaction' }),
+    ).toBeVisible();
+  });
+
+  test('validates payment with field/scalar signature', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    await page.locator('textarea').fill(VERIFIABLE_PAYMENT_JSON);
+    await page
+      .getByRole('button', { name: 'Validate Signature' })
+      .click();
+
+    await expect(page.locator('text=Signature is valid')).toBeVisible();
+  });
+
+  test('shows error for invalid signature values', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    await page.locator('textarea').fill(
+      JSON.stringify({
+        input: {
+          to: 'B62qqL54NrFkuiBf3YQHm6g5VAP7qgC3PRiJRGoiAf4sMR1Liu2Z99U',
+          from: 'B62qqL54NrFkuiBf3YQHm6g5VAP7qgC3PRiJRGoiAf4sMR1Liu2Z99U',
+          fee: '10000000',
+          amount: '1000000000',
+          nonce: '0',
+        },
+        signature: { field: '123', scalar: '456' },
+      }),
+    );
+    await page
+      .getByRole('button', { name: 'Validate Signature' })
+      .click();
+
+    await expect(page.locator('text=verification failed')).toBeVisible();
+  });
+
+  test('shows unsupported for rawSignature format', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    await page.locator('textarea').fill(VALID_PAYMENT_JSON);
+    await page
+      .getByRole('button', { name: 'Validate Signature' })
+      .click();
+
+    await expect(page.locator('text=field/scalar')).toBeVisible();
+  });
+
+  test('shows unsupported for zkApp validation', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    await page.getByRole('button', { name: 'zkApp' }).click();
+    await page.locator('textarea').fill(VALID_ZKAPP_JSON);
+    await page
+      .getByRole('button', { name: 'Validate Signature' })
+      .click();
+
+    await expect(page.locator('text=field/scalar')).toBeVisible();
+  });
+
+  test('validate does not broadcast', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    await page.locator('textarea').fill(VERIFIABLE_PAYMENT_JSON);
+    await page
+      .getByRole('button', { name: 'Validate Signature' })
+      .click();
+
+    await expect(page.locator('text=Signature is valid')).toBeVisible();
+    // Should NOT show broadcast success
+    await expect(
+      page.locator('text=Transaction broadcast successfully'),
+    ).not.toBeVisible();
+  });
+
+  test('shows tracking hint after broadcast', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    await page.locator('textarea').fill(VALID_PAYMENT_JSON);
+    await page
+      .getByRole('button', { name: 'Broadcast Transaction' })
+      .click();
+
+    await expect(
+      page.locator('text=Transaction broadcast successfully'),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=mempool')).toBeVisible();
+    await expect(page.locator('text=track its status')).toBeVisible();
+  });
+
+  test('broadcast another resets form', async ({ page }) => {
+    await page.goto('/#/broadcast');
+
+    await page.locator('textarea').fill(VALID_PAYMENT_JSON);
+    await page
+      .getByRole('button', { name: 'Broadcast Transaction' })
+      .click();
+
+    await expect(
+      page.locator('text=Transaction broadcast successfully'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Click "Broadcast Another"
+    await page.getByRole('button', { name: 'Broadcast Another' }).click();
+
+    // Form should be cleared and ready
+    await expect(page.locator('textarea')).toHaveValue('');
+    await expect(
+      page.getByRole('button', { name: 'Broadcast Transaction' }),
+    ).toBeVisible();
+  });
+});

--- a/e2e/mock-api.ts
+++ b/e2e/mock-api.ts
@@ -269,6 +269,58 @@ async function handleDaemonRequest(route: Route): Promise<void> {
     const body = JSON.parse(postData);
     const query = body.query || '';
 
+    // Handle broadcast mutations
+    if (query.includes('sendPayment')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            sendPayment: {
+              payment: {
+                hash: 'CkpMockPaymentHash12345678901234567890123456789012',
+              },
+            },
+          },
+        }),
+      });
+      return;
+    }
+
+    if (query.includes('sendDelegation')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            sendDelegation: {
+              delegation: {
+                hash: 'CkpMockDelegationHash234567890123456789012345678901',
+              },
+            },
+          },
+        }),
+      });
+      return;
+    }
+
+    if (query.includes('sendZkapp')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            sendZkapp: {
+              zkapp: {
+                hash: 'CkpMockZkAppHash345678901234567890123456789012345',
+              },
+            },
+          },
+        }),
+      });
+      return;
+    }
+
     // Handle bestChain queries (daemon epoch info + transaction listing)
     // Must be checked before 'account' since bestChain queries contain 'accountUpdates'
     if (query.includes('bestChain')) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.1.18",
         "clsx": "^2.1.1",
         "lucide-react": "^0.563.0",
+        "mina-signer": "^4.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.1.1",
@@ -929,6 +930,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@playwright/test": {
@@ -1872,6 +1885,12 @@
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.4",
@@ -2984,6 +3003,16 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mina-signer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mina-signer/-/mina-signer-4.0.0.tgz",
+      "integrity": "sha512-vpPuA3OFrOL2mYTR8UyQHF/cRPJN2WbbvIS+L/FIk22TBT607SyJvXImX1XE9kTwnTO1LIDA/gOFrP3wQHHAZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.7.1",
+        "blakejs": "^1.2.1"
       }
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@tailwindcss/vite": "^4.1.18",
     "clsx": "^2.1.1",
     "lucide-react": "^0.563.0",
+    "mina-signer": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import {
   StakingPage,
   ZkAppsPage,
   AnalyticsPage,
+  BroadcastPage,
   NotFoundPage,
 } from '@/pages';
 
@@ -38,6 +39,7 @@ export function App(): ReactNode {
               <Route path="staking" element={<StakingPage />} />
               <Route path="zkapps" element={<ZkAppsPage />} />
               <Route path="analytics" element={<AnalyticsPage />} />
+              <Route path="broadcast" element={<BroadcastPage />} />
               <Route path="*" element={<NotFoundPage />} />
             </Route>
           </Routes>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -68,6 +68,12 @@ export function Header(): ReactNode {
             >
               Analytics
             </Link>
+            <Link
+              to="/broadcast"
+              className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Broadcast
+            </Link>
           </nav>
 
           {/* Desktop Actions */}
@@ -137,6 +143,13 @@ export function Header(): ReactNode {
               onClick={() => setMobileMenuOpen(false)}
             >
               Analytics
+            </Link>
+            <Link
+              to="/broadcast"
+              className="rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+              onClick={() => setMobileMenuOpen(false)}
+            >
+              Broadcast
             </Link>
           </nav>
           <div className="mt-4 flex flex-col gap-3">

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -23,5 +23,6 @@ export {
   usePaginatedTransactions,
 } from './useTransactions';
 export { usePrice } from './usePrice';
+export { useBroadcast, type TransactionType } from './useBroadcast';
 export { useHistoricalPrice } from './useHistoricalPrice';
 export { useAnalytics, type AnalyticsPeriod } from './useAnalytics';

--- a/src/hooks/useBroadcast.ts
+++ b/src/hooks/useBroadcast.ts
@@ -1,0 +1,146 @@
+import { useState, useCallback } from 'react';
+import {
+  type TransactionType,
+  type BroadcastResult,
+  broadcastPayment,
+  broadcastDelegation,
+  broadcastZkApp,
+  validatePaymentPayload,
+  validateDelegationPayload,
+  validateZkAppPayload,
+} from '@/services/api/broadcast';
+import {
+  type VerifyResult,
+  verifyPayment,
+  verifyDelegation,
+} from '@/services/crypto/verify';
+
+export type { TransactionType, BroadcastResult, VerifyResult };
+
+interface UseBroadcastResult {
+  broadcast: (type: TransactionType, json: string) => Promise<void>;
+  validate: (type: TransactionType, json: string) => void;
+  result: BroadcastResult | null;
+  validationResult: VerifyResult | null;
+  loading: boolean;
+  error: string | null;
+  reset: () => void;
+}
+
+const validators: Record<TransactionType, (p: unknown) => string | null> = {
+  payment: validatePaymentPayload,
+  delegation: validateDelegationPayload,
+  zkapp: validateZkAppPayload,
+};
+
+const broadcasters: Record<
+  TransactionType,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (payload: any) => Promise<BroadcastResult>
+> = {
+  payment: broadcastPayment,
+  delegation: broadcastDelegation,
+  zkapp: broadcastZkApp,
+};
+
+const verifiers: Record<
+  TransactionType,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ((payload: any) => VerifyResult) | null
+> = {
+  payment: verifyPayment,
+  delegation: verifyDelegation,
+  zkapp: null,
+};
+
+export function useBroadcast(): UseBroadcastResult {
+  const [result, setResult] = useState<BroadcastResult | null>(null);
+  const [validationResult, setValidationResult] = useState<VerifyResult | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const broadcast = useCallback(
+    async (type: TransactionType, json: string): Promise<void> => {
+      setLoading(true);
+      setError(null);
+      setResult(null);
+      setValidationResult(null);
+
+      try {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(json);
+        } catch (e) {
+          const msg = e instanceof SyntaxError ? e.message : 'Invalid JSON';
+          setError(`Invalid JSON: ${msg}`);
+          return;
+        }
+
+        const validationError = validators[type](parsed);
+        if (validationError) {
+          setError(validationError);
+          return;
+        }
+
+        const broadcastResult = await broadcasters[type](parsed);
+        setResult(broadcastResult);
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Failed to broadcast transaction',
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
+
+  const validate = useCallback((type: TransactionType, json: string): void => {
+    setError(null);
+    setValidationResult(null);
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(json);
+    } catch (e) {
+      const msg = e instanceof SyntaxError ? e.message : 'Invalid JSON';
+      setError(`Invalid JSON: ${msg}`);
+      return;
+    }
+
+    const structuralError = validators[type](parsed);
+    if (structuralError) {
+      setError(structuralError);
+      return;
+    }
+
+    const verifier = verifiers[type];
+    if (!verifier) {
+      setValidationResult('unsupported');
+      return;
+    }
+
+    setValidationResult(verifier(parsed));
+  }, []);
+
+  const reset = useCallback(() => {
+    setResult(null);
+    setValidationResult(null);
+    setError(null);
+    setLoading(false);
+  }, []);
+
+  return {
+    broadcast,
+    validate,
+    result,
+    validationResult,
+    loading,
+    error,
+    reset,
+  };
+}

--- a/src/pages/BroadcastPage.tsx
+++ b/src/pages/BroadcastPage.tsx
@@ -1,0 +1,414 @@
+import { useState, type ReactNode, type FormEvent } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  ChevronRight,
+  ChevronDown,
+  Info,
+  Loader2,
+  Send,
+  ShieldCheck,
+  Check,
+  X,
+  AlertTriangle,
+} from 'lucide-react';
+import { useNetwork } from '@/hooks';
+import {
+  useBroadcast,
+  type TransactionType,
+  type VerifyResult,
+} from '@/hooks/useBroadcast';
+import { cn } from '@/lib/utils';
+
+const TX_TYPES: { value: TransactionType; label: string }[] = [
+  { value: 'payment', label: 'Payment' },
+  { value: 'delegation', label: 'Delegation' },
+  { value: 'zkapp', label: 'zkApp' },
+];
+
+const EXAMPLES: Record<TransactionType, string> = {
+  payment: JSON.stringify(
+    {
+      input: {
+        from: 'B62q...',
+        to: 'B62q...',
+        amount: '1000000000',
+        fee: '10000000',
+        nonce: '0',
+      },
+      signature: {
+        field: '...',
+        scalar: '...',
+      },
+    },
+    null,
+    2,
+  ),
+  delegation: JSON.stringify(
+    {
+      input: {
+        from: 'B62q...',
+        to: 'B62q...',
+        fee: '10000000',
+        nonce: '0',
+      },
+      signature: {
+        field: '...',
+        scalar: '...',
+      },
+    },
+    null,
+    2,
+  ),
+  zkapp: JSON.stringify(
+    {
+      input: {
+        zkappCommand: {
+          feePayer: { body: { publicKey: 'B62q...', fee: '10000000' } },
+          accountUpdates: [],
+          memo: 'E4Yd...',
+        },
+      },
+    },
+    null,
+    2,
+  ),
+};
+
+const VALIDATION_MESSAGES: Record<
+  VerifyResult,
+  { text: string; color: string; icon: typeof Check }
+> = {
+  valid: {
+    text: 'Signature is valid',
+    color: 'bg-green-500/10 text-green-700 dark:text-green-400',
+    icon: Check,
+  },
+  invalid: {
+    text: 'Signature verification failed \u2014 the signature does not match the transaction data',
+    color: 'bg-destructive/10 text-destructive',
+    icon: X,
+  },
+  unsupported: {
+    text: 'Client-side verification requires field/scalar signature format. zkApp signatures can only be verified by broadcasting.',
+    color: 'bg-yellow-500/10 text-yellow-700 dark:text-yellow-400',
+    icon: AlertTriangle,
+  },
+};
+
+export function BroadcastPage(): ReactNode {
+  const [txType, setTxType] = useState<TransactionType>('payment');
+  const [json, setJson] = useState('');
+  const [showExample, setShowExample] = useState(false);
+  const [showSigningDocs, setShowSigningDocs] = useState(false);
+  const { network } = useNetwork();
+  const {
+    broadcast,
+    validate,
+    result,
+    validationResult,
+    loading,
+    error,
+    reset,
+  } = useBroadcast();
+
+  const handleSubmit = (e: FormEvent): void => {
+    e.preventDefault();
+    broadcast(txType, json);
+  };
+
+  const handleValidate = (): void => {
+    validate(txType, json);
+  };
+
+  const handleReset = (): void => {
+    reset();
+    setJson('');
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Breadcrumb */}
+      <nav aria-label="breadcrumb">
+        <ol className="flex items-center gap-1 text-sm text-muted-foreground">
+          <li>
+            <Link to="/" className="hover:text-foreground">
+              Home
+            </Link>
+          </li>
+          <ChevronRight size={14} />
+          <li className="font-medium text-foreground">Broadcast Transaction</li>
+        </ol>
+      </nav>
+
+      <div>
+        <h1 className="text-2xl font-bold">Broadcast Transaction</h1>
+        <p className="text-sm text-muted-foreground">
+          Broadcasting to {network.displayName}
+        </p>
+      </div>
+
+      {/* Security notice */}
+      <div className="flex items-start gap-2 rounded-md bg-blue-500/10 p-4 text-sm text-blue-700 dark:text-blue-300">
+        <Info size={16} className="mt-0.5 shrink-0" />
+        <span>
+          This tool broadcasts pre-signed transactions. Your private keys never
+          leave your device. Sign transactions offline using the Mina CLI or a
+          compatible wallet.
+        </span>
+      </div>
+
+      {/* Signing documentation */}
+      <div className="rounded-lg border border-border bg-card">
+        <button
+          type="button"
+          onClick={() => setShowSigningDocs(!showSigningDocs)}
+          className="flex w-full items-center gap-2 px-6 py-4 text-left text-sm font-medium hover:bg-accent/50"
+        >
+          <ChevronDown
+            size={14}
+            className={cn(
+              'transition-transform',
+              !showSigningDocs && '-rotate-90',
+            )}
+          />
+          How to sign a transaction
+        </button>
+        {showSigningDocs && (
+          <div className="space-y-4 border-t border-border px-6 py-4 text-sm">
+            <div>
+              <h4 className="font-medium">
+                1. Export your key from the daemon
+              </h4>
+              <pre className="mt-1 overflow-x-auto rounded-md bg-accent p-3 text-xs">
+                {`mina accounts export \\
+  --public-key B62q... \\
+  --config-directory /root/.mina-config \\
+  --privkey-path keys/my-wallet`}
+              </pre>
+            </div>
+            <div>
+              <h4 className="font-medium">2. Get the raw private key</h4>
+              <pre className="mt-1 overflow-x-auto rounded-md bg-accent p-3 text-xs">
+                {`mina advanced dump-keypair --privkey-path keys/my-wallet
+# Outputs: Private key: EK...`}
+              </pre>
+            </div>
+            <div>
+              <h4 className="font-medium">3. Sign with mina-signer</h4>
+              <pre className="mt-1 overflow-x-auto rounded-md bg-accent p-3 text-xs">
+                {`npm install mina-signer`}
+              </pre>
+              <pre className="mt-1 overflow-x-auto rounded-md bg-accent p-3 text-xs">
+                {`import Client from 'mina-signer';
+// Use 'testnet' for mesa/devnet, 'mainnet' for mainnet
+const client = new Client({ network: 'testnet' });
+
+const signed = client.signPayment({
+  from: 'B62q...',
+  to: 'B62q...',
+  amount: '1000000000',  // 1 MINA in nanomina
+  fee: '10000000',       // 0.01 MINA
+  nonce: '0',            // check your account nonce
+}, 'EK...');             // your private key
+
+// Copy this JSON into the broadcast page:
+console.log(JSON.stringify({
+  input: signed.data,
+  signature: signed.signature,
+}, null, 2));`}
+              </pre>
+              <p className="mt-2 text-muted-foreground">
+                For delegation, use{' '}
+                <code className="rounded bg-accent px-1 py-0.5 text-xs">
+                  client.signStakeDelegation(...)
+                </code>{' '}
+                instead — same format but without{' '}
+                <code className="rounded bg-accent px-1 py-0.5 text-xs">
+                  amount
+                </code>
+                .
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Type selector tabs */}
+      <div className="flex gap-2 border-b border-border">
+        {TX_TYPES.map(t => (
+          <button
+            key={t.value}
+            onClick={() => setTxType(t.value)}
+            className={cn(
+              'px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors',
+              txType === t.value
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Main card */}
+      <div className="rounded-lg border border-border bg-card">
+        <div className="border-b border-border px-6 py-4">
+          <h2 className="font-semibold">
+            Send {TX_TYPES.find(t => t.value === txType)?.label}
+          </h2>
+        </div>
+
+        <div className="space-y-4 p-6">
+          {/* Example template */}
+          <div>
+            <button
+              type="button"
+              onClick={() => setShowExample(!showExample)}
+              className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <ChevronDown
+                size={14}
+                className={cn(
+                  'transition-transform',
+                  !showExample && '-rotate-90',
+                )}
+              />
+              Example JSON
+            </button>
+            {showExample && (
+              <pre className="mt-2 overflow-x-auto rounded-md bg-accent p-3 text-xs">
+                {EXAMPLES[txType]}
+              </pre>
+            )}
+          </div>
+
+          {/* Form */}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label
+                htmlFor="tx-json"
+                className="mb-1 block text-sm font-medium"
+              >
+                Signed Transaction JSON
+              </label>
+              <textarea
+                id="tx-json"
+                value={json}
+                onChange={e => {
+                  setJson(e.target.value);
+                  if (validationResult) reset();
+                }}
+                rows={14}
+                placeholder="Paste your signed transaction JSON here..."
+                className={cn(
+                  'w-full rounded-md border bg-background px-3 py-2 font-mono text-sm',
+                  'placeholder:text-muted-foreground',
+                  'focus:outline-none focus:ring-2 focus:ring-ring',
+                  error
+                    ? 'border-destructive focus:ring-destructive'
+                    : 'border-input',
+                )}
+                disabled={loading || !!result}
+              />
+            </div>
+
+            {/* Error display */}
+            {error && (
+              <div className="rounded-md bg-destructive/10 p-4 text-sm text-destructive">
+                {error}
+              </div>
+            )}
+
+            {/* Validation result display */}
+            {validationResult && !error && (
+              <ValidationMessage result={validationResult} />
+            )}
+
+            {/* Success display */}
+            {result && (
+              <div className="space-y-3 rounded-md bg-green-500/10 p-4">
+                <p className="font-medium text-green-700 dark:text-green-400">
+                  Transaction broadcast successfully!
+                </p>
+                <div className="text-sm">
+                  <span className="text-muted-foreground">
+                    Transaction hash:{' '}
+                  </span>
+                  <Link
+                    to={`/transaction/${result.txHash}`}
+                    className="break-all font-mono text-primary hover:underline"
+                  >
+                    {result.txHash}
+                  </Link>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  Your transaction is now in the mempool. Click the hash above
+                  to track its status. It may take a few minutes to be included
+                  in a block.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleReset}
+                  className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium hover:bg-accent/80"
+                >
+                  Broadcast Another
+                </button>
+              </div>
+            )}
+
+            {/* Action buttons */}
+            {!result && (
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={handleValidate}
+                  disabled={loading || !json.trim()}
+                  className={cn(
+                    'inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium',
+                    'border border-input bg-background',
+                    'hover:bg-accent hover:text-accent-foreground',
+                    'disabled:pointer-events-none disabled:opacity-50',
+                  )}
+                >
+                  <ShieldCheck size={16} />
+                  Validate Signature
+                </button>
+                <button
+                  type="submit"
+                  disabled={loading || !json.trim()}
+                  className={cn(
+                    'inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium',
+                    'bg-primary text-primary-foreground',
+                    'hover:bg-primary/90',
+                    'disabled:pointer-events-none disabled:opacity-50',
+                  )}
+                >
+                  {loading ? (
+                    <Loader2 size={16} className="animate-spin" />
+                  ) : (
+                    <Send size={16} />
+                  )}
+                  {loading ? 'Broadcasting...' : 'Broadcast Transaction'}
+                </button>
+              </div>
+            )}
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ValidationMessage({ result }: { result: VerifyResult }): ReactNode {
+  const msg = VALIDATION_MESSAGES[result];
+  const Icon = msg.icon;
+  return (
+    <div
+      className={cn('flex items-start gap-2 rounded-md p-4 text-sm', msg.color)}
+    >
+      <Icon size={16} className="mt-0.5 shrink-0" />
+      <span>{msg.text}</span>
+    </div>
+  );
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -8,4 +8,5 @@ export { AccountPage } from './AccountPage';
 export { StakingPage } from './StakingPage';
 export { ZkAppsPage } from './ZkAppsPage';
 export { AnalyticsPage } from './AnalyticsPage';
+export { BroadcastPage } from './BroadcastPage';
 export { NotFoundPage } from './NotFoundPage';

--- a/src/services/api/broadcast.ts
+++ b/src/services/api/broadcast.ts
@@ -1,0 +1,188 @@
+import { mutateDaemon, isCorsError } from './daemon';
+import { isValidPublicKey } from '@/utils/formatters';
+
+export type TransactionType = 'payment' | 'delegation' | 'zkapp';
+
+export interface BroadcastResult {
+  txHash: string;
+  type: TransactionType;
+}
+
+interface SignatureInput {
+  rawSignature?: string | undefined;
+  field?: string | undefined;
+  scalar?: string | undefined;
+}
+
+interface UserCommandPayload {
+  input: Record<string, unknown>;
+  signature: SignatureInput;
+}
+
+interface ZkAppPayload {
+  input: { zkappCommand: unknown };
+}
+
+const SEND_PAYMENT = `
+  mutation SendPayment($input: SendPaymentInput!, $signature: SignatureInput) {
+    sendPayment(input: $input, signature: $signature) {
+      payment { hash }
+    }
+  }
+`;
+
+const SEND_DELEGATION = `
+  mutation SendDelegation($input: SendDelegationInput!, $signature: SignatureInput) {
+    sendDelegation(input: $input, signature: $signature) {
+      delegation { hash }
+    }
+  }
+`;
+
+const SEND_ZKAPP = `
+  mutation SendZkapp($input: SendZkappInput!) {
+    sendZkapp(input: $input) {
+      zkapp { hash }
+    }
+  }
+`;
+
+function wrapCorsError(err: unknown): never {
+  if (isCorsError(err)) {
+    throw new Error(
+      'Unable to reach the daemon endpoint. This is likely a CORS issue — ' +
+        'the daemon may not allow requests from this origin. ' +
+        'Try using a custom endpoint via the network selector.',
+    );
+  }
+  throw err;
+}
+
+export async function broadcastPayment(
+  payload: UserCommandPayload,
+): Promise<BroadcastResult> {
+  try {
+    const data = await mutateDaemon<{
+      sendPayment: { payment: { hash: string } };
+    }>(SEND_PAYMENT, {
+      input: payload.input,
+      signature: payload.signature,
+    });
+    return { txHash: data.sendPayment.payment.hash, type: 'payment' };
+  } catch (err) {
+    wrapCorsError(err);
+  }
+}
+
+export async function broadcastDelegation(
+  payload: UserCommandPayload,
+): Promise<BroadcastResult> {
+  try {
+    const data = await mutateDaemon<{
+      sendDelegation: { delegation: { hash: string } };
+    }>(SEND_DELEGATION, {
+      input: payload.input,
+      signature: payload.signature,
+    });
+    return { txHash: data.sendDelegation.delegation.hash, type: 'delegation' };
+  } catch (err) {
+    wrapCorsError(err);
+  }
+}
+
+export async function broadcastZkApp(
+  payload: ZkAppPayload,
+): Promise<BroadcastResult> {
+  try {
+    const data = await mutateDaemon<{
+      sendZkapp: { zkapp: { hash: string } };
+    }>(SEND_ZKAPP, { input: payload.input });
+    return { txHash: data.sendZkapp.zkapp.hash, type: 'zkapp' };
+  } catch (err) {
+    wrapCorsError(err);
+  }
+}
+
+function hasString(obj: Record<string, unknown>, key: string): boolean {
+  return typeof obj[key] === 'string' && obj[key].length > 0;
+}
+
+function validateSignature(sig: unknown): string | null {
+  if (!sig || typeof sig !== 'object') {
+    return 'Missing "signature" object';
+  }
+  const s = sig as Record<string, unknown>;
+  const hasRaw = hasString(s, 'rawSignature');
+  const hasFieldScalar = hasString(s, 'field') && hasString(s, 'scalar');
+  if (!hasRaw && !hasFieldScalar) {
+    return 'Signature must include "rawSignature" or both "field" and "scalar"';
+  }
+  return null;
+}
+
+function validatePublicKeys(
+  input: Record<string, unknown>,
+  ...keys: string[]
+): string | null {
+  for (const key of keys) {
+    if (!hasString(input, key)) {
+      return `Missing required field "input.${key}"`;
+    }
+    if (!isValidPublicKey(input[key] as string)) {
+      return `Invalid public key in "input.${key}" — must start with B62 and be 55 characters`;
+    }
+  }
+  return null;
+}
+
+export function validatePaymentPayload(parsed: unknown): string | null {
+  if (!parsed || typeof parsed !== 'object') return 'Expected a JSON object';
+  const obj = parsed as Record<string, unknown>;
+
+  if (!obj.input || typeof obj.input !== 'object') {
+    return 'Missing "input" object';
+  }
+  const input = obj.input as Record<string, unknown>;
+
+  const keyErr = validatePublicKeys(input, 'from', 'to');
+  if (keyErr) return keyErr;
+
+  if (!hasString(input, 'amount'))
+    return 'Missing required field "input.amount"';
+  if (!hasString(input, 'fee')) return 'Missing required field "input.fee"';
+
+  return validateSignature(obj.signature);
+}
+
+export function validateDelegationPayload(parsed: unknown): string | null {
+  if (!parsed || typeof parsed !== 'object') return 'Expected a JSON object';
+  const obj = parsed as Record<string, unknown>;
+
+  if (!obj.input || typeof obj.input !== 'object') {
+    return 'Missing "input" object';
+  }
+  const input = obj.input as Record<string, unknown>;
+
+  const keyErr = validatePublicKeys(input, 'from', 'to');
+  if (keyErr) return keyErr;
+
+  if (!hasString(input, 'fee')) return 'Missing required field "input.fee"';
+
+  return validateSignature(obj.signature);
+}
+
+export function validateZkAppPayload(parsed: unknown): string | null {
+  if (!parsed || typeof parsed !== 'object') return 'Expected a JSON object';
+  const obj = parsed as Record<string, unknown>;
+
+  if (!obj.input || typeof obj.input !== 'object') {
+    return 'Missing "input" object';
+  }
+  const input = obj.input as Record<string, unknown>;
+
+  if (!input.zkappCommand || typeof input.zkappCommand !== 'object') {
+    return 'Missing "input.zkappCommand" object';
+  }
+
+  return null;
+}

--- a/src/services/api/daemon.ts
+++ b/src/services/api/daemon.ts
@@ -35,6 +35,35 @@ export async function queryDaemon<T>(query: string): Promise<T> {
   return result.data;
 }
 
+export async function mutateDaemon<T>(
+  mutation: string,
+  variables: Record<string, unknown>,
+): Promise<T> {
+  const endpoint = getDaemonEndpoint();
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: mutation, variables }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error: ${response.status} ${response.statusText}`);
+  }
+
+  const result = (await response.json()) as GraphQLResponse<T>;
+
+  if (result.errors && result.errors.length > 0) {
+    const errorMessages = result.errors.map(e => e.message).join(', ');
+    throw new Error(`GraphQL error: ${errorMessages}`);
+  }
+
+  if (!result.data) {
+    throw new Error('No data in response');
+  }
+
+  return result.data;
+}
+
 export function isCorsError(error: unknown): boolean {
   return (
     error instanceof TypeError &&

--- a/src/services/crypto/verify.ts
+++ b/src/services/crypto/verify.ts
@@ -1,0 +1,57 @@
+import Client from 'mina-signer';
+import { NETWORKS, resolveActiveNetworkId } from '@/config';
+
+type FieldScalarSig = { field: string; scalar: string };
+
+interface VerifiablePayload {
+  input: Record<string, unknown>;
+  signature: FieldScalarSig | Record<string, unknown>;
+}
+
+export type VerifyResult = 'valid' | 'invalid' | 'unsupported';
+
+function getSignerNetwork(): 'mainnet' | 'testnet' {
+  const networkId = resolveActiveNetworkId();
+  const network = NETWORKS[networkId];
+  return network.id === 'mainnet' ? 'mainnet' : 'testnet';
+}
+
+function isFieldScalar(sig: unknown): sig is FieldScalarSig {
+  if (!sig || typeof sig !== 'object') return false;
+  const s = sig as Record<string, unknown>;
+  return typeof s.field === 'string' && typeof s.scalar === 'string';
+}
+
+export function verifyPayment(payload: VerifiablePayload): VerifyResult {
+  if (!isFieldScalar(payload.signature)) return 'unsupported';
+
+  try {
+    const client = new Client({ network: getSignerNetwork() });
+    const valid = client.verifyPayment({
+      data: payload.input as Parameters<typeof client.verifyPayment>[0]['data'],
+      signature: payload.signature,
+      publicKey: payload.input.from as string,
+    });
+    return valid ? 'valid' : 'invalid';
+  } catch {
+    return 'invalid';
+  }
+}
+
+export function verifyDelegation(payload: VerifiablePayload): VerifyResult {
+  if (!isFieldScalar(payload.signature)) return 'unsupported';
+
+  try {
+    const client = new Client({ network: getSignerNetwork() });
+    const valid = client.verifyStakeDelegation({
+      data: payload.input as Parameters<
+        typeof client.verifyStakeDelegation
+      >[0]['data'],
+      signature: payload.signature,
+      publicKey: payload.input.from as string,
+    });
+    return valid ? 'valid' : 'invalid';
+  } catch {
+    return 'invalid';
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `/broadcast` page that lets users paste pre-signed transaction JSON and broadcast it to the selected network's daemon endpoint. Supports payments, delegations, and zkApp transactions.

- **Broadcast**: sends `sendPayment` / `sendDelegation` / `sendZkapp` GraphQL mutations to the daemon
- **Client-side validation**: verifies signatures locally using `mina-signer` before broadcasting (field/scalar format)
- **Signing docs**: collapsible step-by-step guide on the page (export key → dump-keypair → mina-signer → paste JSON)
- **Transaction tracking**: after broadcast, links to `/transaction/{hash}` with mempool tracking hint

Closes #53

## What changed

| File | Change |
|------|--------|
| `src/services/api/daemon.ts` | Added `mutateDaemon()` — like `queryDaemon` but with variables support |
| `src/services/api/broadcast.ts` | **New** — mutation strings, broadcast functions, input validation |
| `src/services/crypto/verify.ts` | **New** — client-side signature verification via `mina-signer` |
| `src/hooks/useBroadcast.ts` | **New** — hook with `broadcast()`, `validate()`, loading/error/result state |
| `src/pages/BroadcastPage.tsx` | **New** — full page: tabs, JSON textarea, signing docs, validate/broadcast buttons |
| `src/App.tsx` | Added `/broadcast` route |
| `src/components/common/Header.tsx` | Added "Broadcast" nav link (desktop + mobile) |
| `src/pages/index.ts`, `src/hooks/index.ts` | Barrel exports |
| `package.json` | Added `mina-signer` dependency |
| `e2e/broadcast.spec.ts` | **New** — 18 tests covering page load, validation, broadcast, docs toggle, tracking |
| `e2e/mock-api.ts` | Added mutation mock responses for all 3 tx types |

## Validated against live network

Signed a real payment with `mina-signer`, broadcast it through the explorer to the mesa testnet, and confirmed it on-chain:
1. Exported key from mesa daemon → signed with `mina-signer` (testnet network)
2. Pasted into broadcast page → clicked "Validate Signature" → green checkmark
3. Clicked "Broadcast Transaction" → tx hash returned
4. Clicked hash link → transaction detail page showed "Pending"
5. After ~3 minutes → status flipped to "Confirmed", fee deducted from account

## Test plan

- [x] `npx tsc --noEmit` — type check clean
- [x] `npx prettier --check 'src/**/*.{ts,tsx}'` — formatting clean
- [x] `npx vite build` — production build succeeds
- [x] `MOCK_API=true npx playwright test` — all 84 tests pass (66 existing + 18 new)
- [x] Navigate to `/#/broadcast`, switch between Payment/Delegation/zkApp tabs
- [x] Paste invalid JSON → error shown
- [x] Paste valid JSON with field/scalar sig → "Validate Signature" shows green checkmark
- [x] Paste valid JSON with rawSignature → "Validate Signature" shows yellow unsupported message
- [x] Broadcast a real transaction on mesa and track it via the tx hash link (confirmed on-chain)
- [x] Toggle "How to sign a transaction" docs section
- [x] Verify "Broadcast" link appears in both desktop and mobile nav