### PR TITLE
fix: zkApp transactions and analytics — archive flat schema fallback …

### DIFF
--- a/e2e/explorer.spec.ts
+++ b/e2e/explorer.spec.ts
@@ -853,6 +853,28 @@ test.describe('zkApps Page', () => {
 
     await expect(table.or(noActivity)).toBeVisible({ timeout: 15000 });
   });
+
+  test('zkApps page shows zkApp data from flat schema', async ({ page }) => {
+    await page.goto('/#/zkapps');
+
+    // The mock data contains zkApp commands in flat format
+    // The page should show recent transactions section
+    await expect(page.locator('text=Recent zkApp Transactions')).toBeVisible({
+      timeout: 15000,
+    });
+  });
+
+  test('zkApp transaction detail loads via flat schema', async ({ page }) => {
+    await page.goto(`/#/tx/${FIXTURES.transactions.zkAppCommand}`);
+
+    // Should find the zkApp transaction and show details
+    await expect(page.locator('text=Transaction Details')).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Should show zkApp type badge
+    await expect(page.getByText('zkApp', { exact: true })).toBeVisible();
+  });
 });
 
 test.describe('MINA Price Display', () => {

--- a/e2e/mock-api.ts
+++ b/e2e/mock-api.ts
@@ -196,10 +196,12 @@ async function handleArchiveRequest(route: Route): Promise<void> {
       return;
     }
 
-    // Handle paginated transaction queries (archive with transaction fields)
+    // Handle transaction search queries (full, flat, and paginated)
     if (
       query.includes('GetTransactions') ||
-      query.includes('GetTransactionsPaginated')
+      query.includes('GetTransactionsPaginated') ||
+      query.includes('SearchTransactionFlat') ||
+      query.includes('GetZkAppActivityFlat')
     ) {
       await route.fulfill({
         status: 200,

--- a/src/pages/ZkAppsPage.tsx
+++ b/src/pages/ZkAppsPage.tsx
@@ -22,7 +22,8 @@ interface ZkAppSummary {
   latestTxHash: string;
 }
 
-const ZKAPP_ACTIVITY_QUERY = `
+// Nested schema (daemon endpoints)
+const ZKAPP_ACTIVITY_QUERY_NESTED = `
   query GetZkAppActivity($limit: Int!) {
     blocks(
       limit: $limit
@@ -52,7 +53,28 @@ const ZKAPP_ACTIVITY_QUERY = `
   }
 `;
 
-interface ZkAppActivityResponse {
+// Flat schema (archive with ENABLE_BLOCK_TRANSACTION_DETAILS)
+const ZKAPP_ACTIVITY_QUERY_FLAT = `
+  query GetZkAppActivityFlat($limit: Int!) {
+    blocks(
+      limit: $limit
+      sortBy: BLOCKHEIGHT_DESC
+    ) {
+      blockHeight
+      dateTime
+      transactions {
+        zkappCommands {
+          hash
+          feePayer
+          fee
+          memo
+        }
+      }
+    }
+  }
+`;
+
+interface ZkAppActivityNestedResponse {
   blocks: Array<{
     blockHeight: number;
     dateTime: string;
@@ -77,6 +99,21 @@ interface ZkAppActivityResponse {
   }>;
 }
 
+interface ZkAppActivityFlatResponse {
+  blocks: Array<{
+    blockHeight: number;
+    dateTime: string;
+    transactions: {
+      zkappCommands: Array<{
+        hash: string;
+        feePayer: string;
+        fee: string;
+        memo: string;
+      }>;
+    };
+  }>;
+}
+
 export function ZkAppsPage(): ReactNode {
   const [activities, setActivities] = useState<ZkAppActivity[]>([]);
   const [zkApps, setZkApps] = useState<ZkAppSummary[]>([]);
@@ -91,49 +128,76 @@ export function ZkAppsPage(): ReactNode {
 
       try {
         const client = getClient();
-        let data: ZkAppActivityResponse;
+        const allActivities: ZkAppActivity[] = [];
 
+        // Helper to extract from nested schema
+        const extractNested = (data: ZkAppActivityNestedResponse): void => {
+          for (const block of data.blocks) {
+            for (const cmd of block.transactions.zkappCommands || []) {
+              const affectedAccounts = cmd.zkappCommand.accountUpdates
+                .map(u => u.body.publicKey)
+                .filter((pk, idx, arr) => arr.indexOf(pk) === idx);
+
+              allActivities.push({
+                hash: cmd.hash,
+                feePayer: cmd.zkappCommand.feePayer.body.publicKey,
+                affectedAccounts,
+                memo: cmd.zkappCommand.memo,
+                blockHeight: block.blockHeight,
+                dateTime: block.dateTime,
+              });
+            }
+          }
+        };
+
+        // Helper to extract from flat schema
+        const extractFlat = (data: ZkAppActivityFlatResponse): void => {
+          for (const block of data.blocks) {
+            for (const cmd of block.transactions.zkappCommands || []) {
+              allActivities.push({
+                hash: cmd.hash,
+                feePayer: cmd.feePayer,
+                affectedAccounts: [],
+                memo: cmd.memo,
+                blockHeight: block.blockHeight,
+                dateTime: block.dateTime,
+              });
+            }
+          }
+        };
+
+        // Fallback chain: nested → flat → error
         try {
-          data = await client.query<ZkAppActivityResponse>(
-            ZKAPP_ACTIVITY_QUERY,
+          const data = await client.query<ZkAppActivityNestedResponse>(
+            ZKAPP_ACTIVITY_QUERY_NESTED,
             { limit: 500 },
           );
-        } catch (queryError) {
-          // Check if the error is about zkappCommands not being available
+          extractNested(data);
+        } catch (nestedError) {
           const errorMessage =
-            queryError instanceof Error ? queryError.message : '';
+            nestedError instanceof Error ? nestedError.message : '';
           if (
             errorMessage.includes('zkappCommands') ||
             errorMessage.includes('Cannot query field')
           ) {
-            // zkappCommands not supported on this network/endpoint
-            setActivities([]);
-            setZkApps([]);
-            setError(
-              'zkApp data is not available on the current network endpoint. ' +
-                'Try switching to a different network or endpoint that supports zkApp queries.',
-            );
-            return;
-          }
-          throw queryError;
-        }
-
-        // Extract zkApp activities from blocks
-        const allActivities: ZkAppActivity[] = [];
-        for (const block of data.blocks) {
-          for (const cmd of block.transactions.zkappCommands || []) {
-            const affectedAccounts = cmd.zkappCommand.accountUpdates
-              .map(u => u.body.publicKey)
-              .filter((pk, idx, arr) => arr.indexOf(pk) === idx); // unique
-
-            allActivities.push({
-              hash: cmd.hash,
-              feePayer: cmd.zkappCommand.feePayer.body.publicKey,
-              affectedAccounts,
-              memo: cmd.zkappCommand.memo,
-              blockHeight: block.blockHeight,
-              dateTime: block.dateTime,
-            });
+            // Try flat schema
+            try {
+              const data = await client.query<ZkAppActivityFlatResponse>(
+                ZKAPP_ACTIVITY_QUERY_FLAT,
+                { limit: 500 },
+              );
+              extractFlat(data);
+            } catch {
+              setActivities([]);
+              setZkApps([]);
+              setError(
+                'zkApp data is not available on the current network endpoint. ' +
+                  'Try switching to a different network or endpoint that supports zkApp queries.',
+              );
+              return;
+            }
+          } else {
+            throw nestedError;
           }
         }
 

--- a/src/services/api/analytics.ts
+++ b/src/services/api/analytics.ts
@@ -56,7 +56,7 @@ const BLOCKS_ANALYTICS_QUERY = `
   }
 `;
 
-// Fallback query without zkappCommands
+// Fallback query without txFees (archive may not support it) but keeps zkApp counts
 const BLOCKS_ANALYTICS_QUERY_BASIC = `
   query BlocksAnalyticsBasic($limit: Int, $dateTime_gte: DateTime) {
     blocks(
@@ -66,9 +66,11 @@ const BLOCKS_ANALYTICS_QUERY_BASIC = `
     ) {
       blockHeight
       dateTime
-      txFees
       transactions {
         userCommands {
+          hash
+        }
+        zkappCommands {
           hash
         }
       }

--- a/src/services/api/transactions.ts
+++ b/src/services/api/transactions.ts
@@ -191,7 +191,42 @@ const SEARCH_TRANSACTION_QUERY_FULL = `
   }
 `;
 
-// Fallback query without zkappCommands (for endpoints that don't support it)
+// Fallback query with flat zkApp schema (archive with ENABLE_BLOCK_TRANSACTION_DETAILS)
+const SEARCH_TRANSACTION_QUERY_FLAT = `
+  query SearchTransactionFlat($limit: Int!) {
+    blocks(
+      limit: $limit
+      sortBy: BLOCKHEIGHT_DESC
+    ) {
+      blockHeight
+      stateHash
+      dateTime
+      transactions {
+        userCommands {
+          hash
+          kind
+          from
+          to
+          amount
+          fee
+          memo
+          nonce
+          failureReason
+        }
+        zkappCommands {
+          hash
+          feePayer
+          fee
+          memo
+          status
+          failureReason
+        }
+      }
+    }
+  }
+`;
+
+// Last-resort query without zkappCommands (for endpoints without transaction details)
 const SEARCH_TRANSACTION_QUERY_BASIC = `
   query SearchTransactionBasic($limit: Int!) {
     blocks(
@@ -252,6 +287,35 @@ interface SearchTransactionResponse {
             };
           }>;
         };
+      }>;
+    };
+  }>;
+}
+
+interface SearchTransactionFlatResponse {
+  blocks: Array<{
+    blockHeight: number;
+    stateHash: string;
+    dateTime: string;
+    transactions: {
+      userCommands: Array<{
+        hash: string;
+        kind: string;
+        from: string;
+        to: string;
+        amount: string;
+        fee: string;
+        memo: string;
+        nonce: number;
+        failureReason: string | null;
+      }>;
+      zkappCommands: Array<{
+        hash: string;
+        feePayer: string;
+        fee: string;
+        memo: string;
+        status: string;
+        failureReason: string | null;
       }>;
     };
   }>;
@@ -360,7 +424,56 @@ export async function fetchTransactionByHash(
     return null;
   };
 
-  // Try full query first (with zkappCommands)
+  // Helper to search flat-schema blocks for the transaction
+  const searchBlocksFlat = (
+    data: SearchTransactionFlatResponse,
+  ): TransactionDetail | null => {
+    for (const block of data.blocks) {
+      const userCmd = block.transactions.userCommands?.find(
+        tx => tx.hash === hash,
+      );
+      if (userCmd) {
+        return {
+          hash: userCmd.hash,
+          type: 'user_command',
+          status: 'confirmed',
+          blockHeight: block.blockHeight,
+          blockStateHash: block.stateHash,
+          dateTime: block.dateTime,
+          kind: userCmd.kind,
+          from: userCmd.from,
+          to: userCmd.to,
+          amount: userCmd.amount,
+          fee: userCmd.fee,
+          memo: userCmd.memo,
+          nonce: userCmd.nonce,
+          failureReason: userCmd.failureReason,
+        };
+      }
+
+      const zkAppCmd = block.transactions.zkappCommands?.find(
+        tx => tx.hash === hash,
+      );
+      if (zkAppCmd) {
+        return {
+          hash: zkAppCmd.hash,
+          type: 'zkapp_command',
+          status: 'confirmed',
+          blockHeight: block.blockHeight,
+          blockStateHash: block.stateHash,
+          dateTime: block.dateTime,
+          feePayer: zkAppCmd.feePayer,
+          fee: zkAppCmd.fee,
+          memo: zkAppCmd.memo,
+          failureReason: zkAppCmd.failureReason,
+        };
+      }
+    }
+    return null;
+  };
+
+  // Fallback chain: nested (daemon) → flat (archive) → basic (no zkApps)
+  // Try nested query first (works for daemon endpoints)
   try {
     const data = await client.query<SearchTransactionResponse>(
       SEARCH_TRANSACTION_QUERY_FULL,
@@ -369,27 +482,39 @@ export async function fetchTransactionByHash(
     const result = searchBlocks(data);
     if (result) return result;
   } catch (error) {
-    // Check if zkappCommands is not supported
     const errorMessage = error instanceof Error ? error.message : '';
     if (
       errorMessage.includes('zkappCommands') ||
       errorMessage.includes('Cannot query field')
     ) {
-      // Fall back to basic query without zkappCommands
-      console.log('[API] zkappCommands not supported, using basic query...');
-      try {
-        const data = await client.query<SearchTransactionResponse>(
-          SEARCH_TRANSACTION_QUERY_BASIC,
-          { limit: 1000 },
-        );
-        const result = searchBlocks(data);
-        if (result) return result;
-      } catch (basicError) {
-        console.error('[API] Error with basic transaction search:', basicError);
-      }
+      // Nested schema not supported — skip to flat and basic below
     } else {
       console.error('[API] Error searching for transaction:', error);
     }
+  }
+
+  // Try flat query (archive with ENABLE_BLOCK_TRANSACTION_DETAILS)
+  try {
+    const data = await client.query<SearchTransactionFlatResponse>(
+      SEARCH_TRANSACTION_QUERY_FLAT,
+      { limit: 1000 },
+    );
+    const result = searchBlocksFlat(data);
+    if (result) return result;
+  } catch {
+    // Flat query failed — try basic (no zkApp data)
+  }
+
+  // Last resort: basic query (no zkappCommands at all)
+  try {
+    const data = await client.query<SearchTransactionResponse>(
+      SEARCH_TRANSACTION_QUERY_BASIC,
+      { limit: 1000 },
+    );
+    const result = searchBlocks(data);
+    if (result) return result;
+  } catch (basicError) {
+    console.error('[API] Error with basic transaction search:', basicError);
   }
 
   return null;
@@ -473,7 +598,55 @@ export async function fetchAccountTransactions(
     }
   };
 
-  // Try full query first
+  // Helper to extract from flat-schema blocks
+  const extractTransactionsFlat = (
+    data: SearchTransactionFlatResponse,
+  ): void => {
+    for (const block of data.blocks) {
+      for (const cmd of block.transactions.userCommands || []) {
+        if (cmd.from === publicKey) {
+          transactions.push({
+            hash: cmd.hash,
+            type: 'sent',
+            kind: cmd.kind,
+            counterparty: cmd.to,
+            amount: cmd.amount,
+            fee: cmd.fee,
+            blockHeight: block.blockHeight,
+            dateTime: block.dateTime,
+            memo: cmd.memo,
+          });
+        } else if (cmd.to === publicKey) {
+          transactions.push({
+            hash: cmd.hash,
+            type: 'received',
+            kind: cmd.kind,
+            counterparty: cmd.from,
+            amount: cmd.amount,
+            fee: cmd.fee,
+            blockHeight: block.blockHeight,
+            dateTime: block.dateTime,
+            memo: cmd.memo,
+          });
+        }
+      }
+
+      for (const cmd of block.transactions.zkappCommands || []) {
+        if (cmd.feePayer === publicKey) {
+          transactions.push({
+            hash: cmd.hash,
+            type: 'zkapp',
+            fee: cmd.fee,
+            blockHeight: block.blockHeight,
+            dateTime: block.dateTime,
+            memo: cmd.memo,
+          });
+        }
+      }
+    }
+  };
+
+  // Fallback chain: nested (daemon) → flat (archive) → basic (no zkApps)
   try {
     const data = await client.query<SearchTransactionResponse>(
       SEARCH_TRANSACTION_QUERY_FULL,
@@ -481,27 +654,33 @@ export async function fetchAccountTransactions(
     );
     extractTransactions(data);
   } catch (error) {
-    // Check if zkappCommands is not supported
     const errorMessage = error instanceof Error ? error.message : '';
-    if (
+    const unsupported =
       errorMessage.includes('zkappCommands') ||
-      errorMessage.includes('Cannot query field')
-    ) {
-      // Fall back to basic query
-      console.log(
-        '[API] zkappCommands not supported, using basic query for account transactions...',
-      );
+      errorMessage.includes('Cannot query field');
+
+    if (unsupported) {
+      // Try flat schema
       try {
-        const data = await client.query<SearchTransactionResponse>(
-          SEARCH_TRANSACTION_QUERY_BASIC,
+        const data = await client.query<SearchTransactionFlatResponse>(
+          SEARCH_TRANSACTION_QUERY_FLAT,
           { limit },
         );
-        extractTransactions(data);
-      } catch (basicError) {
-        console.error(
-          '[API] Error with basic account transactions:',
-          basicError,
-        );
+        extractTransactionsFlat(data);
+      } catch {
+        // Flat also failed — try basic (no zkApp data)
+        try {
+          const data = await client.query<SearchTransactionResponse>(
+            SEARCH_TRANSACTION_QUERY_BASIC,
+            { limit },
+          );
+          extractTransactions(data);
+        } catch (basicError) {
+          console.error(
+            '[API] Error with basic account transactions:',
+            basicError,
+          );
+        }
       }
     } else {
       console.error('[API] Error fetching account transactions:', error);


### PR DESCRIPTION
…(#54)


## Summary

Fixes zkApp transaction detail, zkApps page, and Analytics zkApp counts by adding a flat-schema fallback for archive queries. The archive uses a flat zkApp schema (`feePayer`, `fee`, `memo` as direct fields) that differs from the daemon's nested schema — the code was only trying the nested format then dropping zkApp data entirely.

Closes #54

## What changed

- **`transactions.ts`**: Added `SEARCH_TRANSACTION_QUERY_FLAT` and a 3-step fallback: nested → flat → basic (no zkApps). Applies to both `fetchTransactionByHash()` and `fetchAccountTransactions()`.
- **`ZkAppsPage.tsx`**: Same nested → flat → error fallback for the zkApp activity query.
- **`analytics.ts`**: Kept `zkappCommands { hash }` in the basic fallback query and removed unsupported `txFees` field.
- **`mock-api.ts`**: Route flat-schema query names to existing fixtures.
- **`explorer.spec.ts`**: 2 new tests for zkApp flat schema data and zkApp tx detail lookup.

## Validated against live mesa archive

- zkApp tx detail loads via flat fallback (`5JvHjhbHmbQrX59ZBVBd...`)
- zkApps page shows active zkApps and recent transactions
- Analytics shows non-zero zkApp counts
- 102 e2e tests pass, 0 regressions