### PR TITLE
feat: add Trailblazer MUT testnet

### DIFF
--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -56,6 +56,16 @@ const COMPILED_NETWORKS: Record<string, NetworkConfig> = {
       },
     ],
   },
+  'trailblazer-mut': {
+    id: 'trailblazer-mut',
+    name: 'trailblazer-mut',
+    displayName: 'Trailblazer MUT',
+    archiveEndpoint:
+      'https://archive-node-api.mesa-mut.minaprotocol.com',
+    daemonEndpoint:
+      'https://plain-1-graphql.mesa-mut.minaprotocol.com/graphql',
+    isTestnet: true,
+  },
   devnet: {
     id: 'devnet',
     name: 'devnet',

--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -60,10 +60,8 @@ const COMPILED_NETWORKS: Record<string, NetworkConfig> = {
     id: 'trailblazer-mut',
     name: 'trailblazer-mut',
     displayName: 'Trailblazer MUT',
-    archiveEndpoint:
-      'https://archive-node-api.mesa-mut.minaprotocol.com',
-    daemonEndpoint:
-      'https://plain-1-graphql.mesa-mut.minaprotocol.com/graphql',
+    archiveEndpoint: 'https://archive-node-api.mesa-mut.minaprotocol.com',
+    daemonEndpoint: 'https://plain-1-graphql.mesa-mut.minaprotocol.com/graphql',
     isTestnet: true,
   },
   devnet: {


### PR DESCRIPTION
  New mesa-mut network with archive and daemon endpoints at
  minaprotocol.com. Archive uses limited Block schema (no protocolState)
  — handled by existing BASIC query fallback.